### PR TITLE
Fix/accept 0 in distribution

### DIFF
--- a/lib/peep/storage.ex
+++ b/lib/peep/storage.ex
@@ -21,7 +21,7 @@ defmodule Peep.Storage do
   end
 
   def insert_metric(tid, %Metrics.Distribution{} = metric, value, tags) do
-    bucket = ceil(:math.log(value) / @denominator)
+    bucket = calculate_bucket(value)
     bucket_key = {metric, tags, bucket}
     sum_key = {metric, tags, :sum}
     :ets.update_counter(tid, bucket_key, {2, 1}, {bucket_key, 0})
@@ -57,6 +57,14 @@ defmodule Peep.Storage do
           {bucket_idx_to_upper_bound(bucket_idx), count}
         end
     end
+  end
+
+  defp calculate_bucket(0) do
+    0
+  end
+
+  defp calculate_bucket(value) do
+    ceil(:math.log(value) / @denominator)
   end
 
   defp group_metrics(metrics), do: group_metrics(metrics, %{})

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -39,16 +39,16 @@ defmodule StorageTest do
   end
 
   test "a distribution can be stored and retrieved" do
-    tid = Storage.new()
+    tid = Storage.new(:distribution_storage_test)
 
     dist = Metrics.distribution("storage.test.distribution")
 
-    for i <- 1..1000 do
+    for i <- 0..1000 do
       Storage.insert_metric(tid, dist, i, [])
     end
 
     expected = %{
-      "1.0" => 1,
+      "1.0" => 2,
       "2.23152" => 1,
       "3.333505" => 1,
       "4.074283" => 1,


### PR DESCRIPTION
This fix enables recording a value of 0 in a distribution.