### PR TITLE
Use default max_value for distribution

### DIFF
--- a/lib/peep/event_handler.ex
+++ b/lib/peep/event_handler.ex
@@ -83,6 +83,9 @@ defmodule Peep.EventHandler do
     key = :max_value
 
     case Keyword.get(opts, key) do
+      nil ->
+        true
+
       n when is_number(n) ->
         true
 


### PR DESCRIPTION
This PR allows declaring distributions without providing a `:max_value`, defaulting to the declared `1_000_000_000`.