### PR TITLE
Fix/detach handlers on termination

### DIFF
--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -95,6 +95,7 @@ defmodule Peep do
 
   @impl true
   def init(options) do
+    Process.flag(:trap_exit, true)
     tid = Storage.new(options.name)
 
     metrics = options.metrics
@@ -144,6 +145,11 @@ defmodule Peep do
 
     set_statsd_timer(statsd_opts[:flush_interval_ms])
     {:noreply, %State{state | statsd_state: new_statsd_state}}
+  end
+
+  @impl true
+  def terminate(:shutdown, %{handler_ids: handler_ids}) do
+    EventHandler.detach(handler_ids)
   end
 
   defp set_statsd_timer(interval) do

--- a/lib/peep/event_handler.ex
+++ b/lib/peep/event_handler.ex
@@ -28,6 +28,10 @@ defmodule Peep.EventHandler do
     end
   end
 
+  def detach(handler_ids) do
+    Enum.each(handler_ids, fn id -> :telemetry.detach(id) end)
+  end
+
   def handle_event(_event, measurements, metadata, %{
         tid: tid,
         metrics: metrics,

--- a/test/peep_test.exs
+++ b/test/peep_test.exs
@@ -119,4 +119,26 @@ defmodule PeepTest do
       assert String.contains?(logs, "Dropping #{inspect(event_name)}")
     end
   end
+
+  test "Handlers are detached on shutdown" do
+    prefix = [:peep, :shutdown_test]
+
+    metric =
+      Metrics.counter(prefix ++ [:counter])
+
+    {:ok, options} =
+      [
+        name: :"#{__MODULE__}_shutdown_test",
+        metrics: [metric]
+      ]
+      |> Peep.Options.validate()
+
+    {:ok, pid} = GenServer.start(Peep, options, name: options.name)
+
+    assert length(:telemetry.list_handlers(prefix)) == 1
+
+    GenServer.stop(pid, :shutdown)
+
+    assert [] == :telemetry.list_handlers(prefix)
+  end
 end


### PR DESCRIPTION
This PR ensures that the event handlers are detached when Peep terminates.