### PR TITLE
ft: custom Prometheus types

### DIFF
--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -59,6 +59,13 @@ defmodule Peep do
   each reporting period, metrics collected by a `Peep` reporter will be
   collected into a minimum number of packets. Users can set the maximum packet
   size in `Peep.Options`.
+
+  ## Supported `:reporter_options`
+
+  - `:prometheus_type` - when using `sum/2` or `last_value/2` you can use this
+    option to define Prometheus' type used by such metric. By default `sum/2`
+    uses `counter` and `last_value/2` uses `gauge`. It can be useful when some
+    values are already precomputed, for example presummed socket stats.
   """
   use GenServer
   require Logger

--- a/lib/peep/prometheus.ex
+++ b/lib/peep/prometheus.ex
@@ -22,12 +22,12 @@ defmodule Peep.Prometheus do
     format_standard(metric, "counter")
   end
 
-  defp format({%Sum{}, _series} = metric) do
-    format_standard(metric, "counter")
+  defp format({%Sum{} = spec, _series} = metric) do
+    format_standard(metric, spec.reporter_options[:prometheus_type] || "counter")
   end
 
-  defp format({%LastValue{}, _series} = metric) do
-    format_standard(metric, "gauge")
+  defp format({%LastValue{} = spec, _series} = metric) do
+    format_standard(metric, spec.reporter_options[:prometheus_type] || "gauge")
   end
 
   defp format({%Distribution{} = metric, tagged_series}) do


### PR DESCRIPTION
Sometimes it may be useful to change type of `sum` and `last_value` metrics to accustom alternative representation. For example you may want to use `counter` type with `last_value` to store values that are already summed instead of summing them in Telemetry.
