### PR TITLE
Gracefully handle termination and unexpected messages

### DIFF
--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -155,7 +155,7 @@ defmodule Peep do
   end
 
   @impl true
-  def terminate(:shutdown, %{handler_ids: handler_ids}) do
+  def terminate(_reason, %{handler_ids: handler_ids}) do
     EventHandler.detach(handler_ids)
   end
 

--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -154,6 +154,16 @@ defmodule Peep do
     {:noreply, %State{state | statsd_state: new_statsd_state}}
   end
 
+  def handle_info(_msg, state) do
+    # In particular, OTP can sometimes leak `:inet_reply` messages when a UDS datagram
+    # socket blocks, and Peep should not terminate the server and lose state when that
+    # happens.
+    # 
+    # https://github.com/rkallos/peep/pull/17
+    # https://github.com/erlang/otp/issues/8989
+    {:noreply, state}
+  end
+
   @impl true
   def terminate(_reason, %{handler_ids: handler_ids}) do
     EventHandler.detach(handler_ids)


### PR DESCRIPTION
We've recently tried to adopt Peep as a replacement for TelemetryMetricsStatsd. We just switched to using a UDS to send metrics to Datadog, and in the process found this bug in OTP: https://github.com/erlang/otp/issues/8989. We optimistically hoped Peep's batching would avoid this issue.

It turned out to still hit that issue, which is fine: that's not Peep's bug. But the way it affected Peep was very destructive: when Peep received an unexpected message, it brought down the entire application! 😱 

I believe the reason for this is that the error raised from Peep not having a matching `handle_info` clause for the message caused the Peep server to terminate for a reason other than `:shutdown`, which is the only reason its `terminate` callback is able to handle. So another function clause error is raised, this time while handling the trapped exit, and I think this error is what brings the whole application crashing down. I'm not an OTP expert (yet) but my intuition is that an error raised while handling a trapped exit breaks the normal restarting that would be handled by the server's supervisor, and it cascades up from there.

Even if you're not hitting the OTP bug mentioned above, this behavior is very easy to reproduce: lookup the PID for the `name` used for Peep with `GenServer.whereis` and then `send` it an arbitrary message it's not expecting.

So I've made two changes here that seem to address this issue for us. First, accept any reason for `terminate` rather than just `:shutdown`. It seems to be very important for `terminate` to always succeed, and I don't see a need to handle any specific exit reason differently.

That change is sufficient to make the Peep server restart correctly when it receives unexpected processes, and presumably if it were to exit for any other unexpected reason. But given that we are still being hit by that OTP bug, we would still rather the server not restart on us. So I also introduced a catch-all `handle_info` case that logs a warning for unexpected messages, which allows the server to keep running. This avoids it dropping its ETS table when we hit this bug. I can understand if you wouldn't want to accept that commit though on the basis that it's better to crash early for unexpected things happening.

Thanks for your work and thank you for your time!