### PR TITLE
Add Peep.Storage.Striped

### DIFF
--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -105,6 +105,20 @@ defmodule Peep do
   end
 
   @doc """
+  Returns measurements about the size of a running Peep's storage, in number of
+  ETS elements and in bytes of memory.
+  """
+  def storage_size(name) do
+    case Peep.Persistent.storage(name) do
+      {storage_mod, storage} ->
+        storage_mod.storage_size(storage)
+
+      _ ->
+        nil
+    end
+  end
+
+  @doc """
   Fetches all metrics from the worker. Called when preparing Prometheus or
   StatsD data.
   """

--- a/lib/peep/event_handler.ex
+++ b/lib/peep/event_handler.ex
@@ -2,7 +2,6 @@ defmodule Peep.EventHandler do
   @moduledoc false
   require Logger
 
-  alias Peep.Storage
   alias Telemetry.Metrics.{Counter, Summary, Distribution}
 
   def attach(metrics, name, global_tags) do
@@ -45,8 +44,7 @@ defmodule Peep.EventHandler do
 
         tags = Map.new(metric.tags, &{&1, Map.get(tag_values, &1, "")})
 
-        {:ok, tid} = Peep.Persistent.tid(name)
-        Storage.insert_metric(tid, metric, value, tags)
+        Peep.insert_metric(name, metric, value, tags)
       end
     end
   end

--- a/lib/peep/options.ex
+++ b/lib/peep/options.ex
@@ -59,6 +59,15 @@ defmodule Peep.Options do
       doc:
         "Additional tags published with every metric. " <>
           "Global tags are overriden by the tags specified in the metric definition."
+    ],
+    storage: [
+      type: {:in, [:default, :striped]},
+      default: :default,
+      doc:
+        "Which storage implementation to use. " <>
+          "`:default` uses a single ETS table, with some optimizations for concurrent writing. " <>
+          "`:striped` uses one ETS table per scheduler thread, " <>
+          "which trades memory for less lock contention for concurrent writes."
     ]
   ]
 
@@ -69,6 +78,7 @@ defmodule Peep.Options do
   """
 
   defstruct Keyword.keys(@schema)
+  @type t() :: %__MODULE__{}
 
   @spec docs() :: String.t()
   def docs do

--- a/lib/peep/persistent.ex
+++ b/lib/peep/persistent.ex
@@ -17,7 +17,7 @@ defmodule Peep.Persistent do
     storage =
       case storage_impl do
         :default ->
-          {:default, Peep.Storage.new()}
+          {:default, Peep.Storage.ETS.new()}
 
         :striped ->
           {:striped, Peep.Storage.Striped.new()}
@@ -50,7 +50,7 @@ defmodule Peep.Persistent do
   def storage(name) when is_atom(name) do
     case fetch(name) do
       %__MODULE__{storage: {:default, tid}} ->
-        {Peep.Storage, tid}
+        {Peep.Storage.ETS, tid}
 
       %__MODULE__{storage: {:striped, tids}} ->
         {Peep.Storage.Striped, tids}

--- a/lib/peep/persistent.ex
+++ b/lib/peep/persistent.ex
@@ -1,0 +1,68 @@
+defmodule Peep.Persistent do
+  @moduledoc false
+  defstruct [:name, :storage]
+
+  @type name() :: atom()
+
+  @typep storage_default() :: {:default, :ets.tid()}
+  @typep storage_striped() :: {:striped, %{pos_integer() => :ets.tid()}}
+  @typep storage() :: storage_default() | storage_striped()
+
+  @type t() :: %__MODULE__{name: name(), storage: storage()}
+
+  @spec new(Peep.Options.t()) :: t()
+  def new(%Peep.Options{} = options) do
+    %Peep.Options{name: name, storage: storage_impl} = options
+
+    storage =
+      case storage_impl do
+        :default ->
+          {:default, Peep.Storage.new()}
+
+        :striped ->
+          {:striped, Peep.Storage.Striped.new()}
+      end
+
+    %__MODULE__{
+      name: name,
+      storage: storage
+    }
+  end
+
+  @spec store(t()) :: :ok
+  def store(%__MODULE__{} = term) do
+    %__MODULE__{name: name} = term
+    :persistent_term.put(key(name), term)
+  end
+
+  @spec fetch(name()) :: t() | nil
+  def fetch(name) when is_atom(name) do
+    :persistent_term.get(key(name), nil)
+  end
+
+  @spec erase(name()) :: :ok
+  def erase(name) when is_atom(name) do
+    :persistent_term.erase(name)
+    :ok
+  end
+
+  @spec tid(name()) :: {:ok, :ets.tid()} | nil
+  def tid(name) when is_atom(name) do
+    id = :erlang.system_info(:scheduler_id)
+
+    case fetch(name) do
+      %__MODULE__{storage: {:default, tid}} ->
+        {:ok, tid}
+
+      %__MODULE__{storage: {:striped, %{^id => tid}}} ->
+        {:ok, tid}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp key(name) when is_atom(name) do
+    {Peep, name}
+  end
+end

--- a/lib/peep/persistent.ex
+++ b/lib/peep/persistent.ex
@@ -46,16 +46,14 @@ defmodule Peep.Persistent do
     :ok
   end
 
-  @spec tid(name()) :: {:ok, :ets.tid()} | nil
-  def tid(name) when is_atom(name) do
-    id = :erlang.system_info(:scheduler_id)
-
+  @spec storage(name()) :: {module(), term()} | nil
+  def storage(name) when is_atom(name) do
     case fetch(name) do
       %__MODULE__{storage: {:default, tid}} ->
-        {:ok, tid}
+        {Peep.Storage, tid}
 
-      %__MODULE__{storage: {:striped, %{^id => tid}}} ->
-        {:ok, tid}
+      %__MODULE__{storage: {:striped, tids}} ->
+        {Peep.Storage.Striped, tids}
 
       _ ->
         nil

--- a/lib/peep/storage.ex
+++ b/lib/peep/storage.ex
@@ -1,0 +1,9 @@
+defmodule Peep.Storage do
+  alias Telemetry.Metrics
+
+  @callback new() :: term()
+  @callback storage_size(term()) :: %{size: non_neg_integer(), memory: non_neg_integer()}
+  @callback insert_metric(term(), Metrics.t(), term(), map()) :: any()
+  @callback get_all_metrics(term()) :: map()
+  @callback get_metric(term(), Metrics.t(), map()) :: any()
+end

--- a/lib/peep/storage.ex
+++ b/lib/peep/storage.ex
@@ -18,37 +18,6 @@ defmodule Peep.Storage do
     :ets.new(__MODULE__, opts)
   end
 
-  @spec new(atom) :: :ets.tid()
-  def new(name) do
-    opts = [
-      :public,
-      # Enabling read_concurrency makes switching between reads and writes
-      # more expensive. The goal is to ruthlessly optimize writes, even at
-      # the cost of read performance.
-      read_concurrency: false,
-      write_concurrency: true,
-      decentralized_counters: true
-    ]
-
-    :ets.new(name, opts)
-  end
-
-  @spec new_many(atom()) :: %{pos_integer() => :ets.tid()}
-  def new_many(name) do
-    opts = [
-      :public,
-      # Enabling read_concurrency makes switching between reads and writes
-      # more expensive. The goal is to ruthlessly optimize writes, even at
-      # the cost of read performance.
-      read_concurrency: false,
-      write_concurrency: true,
-      decentralized_counters: true
-    ]
-
-    n_schedulers = :erlang.system_info(:schedulers_online)
-    Map.new(1..n_schedulers, fn i -> {i, :ets.new(name, opts)} end)
-  end
-
   def insert_metric(tid, %Metrics.Counter{} = metric, _value, %{} = tags) do
     key = {metric, tags, :erlang.system_info(:scheduler_id)}
     :ets.update_counter(tid, key, {2, 1}, {key, 0})

--- a/lib/peep/storage.ex
+++ b/lib/peep/storage.ex
@@ -3,11 +3,25 @@ defmodule Peep.Storage do
   alias __MODULE__
   alias Telemetry.Metrics
 
+  @spec new() :: :ets.tid()
+  def new() do
+    opts = [
+      :public,
+      # Enabling read_concurrency makes switching between reads and writes
+      # more expensive. The goal is to ruthlessly optimize writes, even at
+      # the cost of read performance.
+      read_concurrency: false,
+      write_concurrency: true,
+      decentralized_counters: true
+    ]
+
+    :ets.new(__MODULE__, opts)
+  end
+
   @spec new(atom) :: :ets.tid()
   def new(name) do
     opts = [
       :public,
-      :named_table,
       # Enabling read_concurrency makes switching between reads and writes
       # more expensive. The goal is to ruthlessly optimize writes, even at
       # the cost of read performance.
@@ -17,6 +31,22 @@ defmodule Peep.Storage do
     ]
 
     :ets.new(name, opts)
+  end
+
+  @spec new_many(atom()) :: %{pos_integer() => :ets.tid()}
+  def new_many(name) do
+    opts = [
+      :public,
+      # Enabling read_concurrency makes switching between reads and writes
+      # more expensive. The goal is to ruthlessly optimize writes, even at
+      # the cost of read performance.
+      read_concurrency: false,
+      write_concurrency: true,
+      decentralized_counters: true
+    ]
+
+    n_schedulers = :erlang.system_info(:schedulers_online)
+    Map.new(1..n_schedulers, fn i -> {i, :ets.new(name, opts)} end)
   end
 
   def insert_metric(tid, %Metrics.Counter{} = metric, _value, %{} = tags) do

--- a/lib/peep/storage.ex
+++ b/lib/peep/storage.ex
@@ -18,6 +18,13 @@ defmodule Peep.Storage do
     :ets.new(__MODULE__, opts)
   end
 
+  def storage_size(tid) do
+    %{
+      size: :ets.info(tid, :size),
+      memory: :ets.info(tid, :memory) * :erlang.system_info(:wordsize)
+    }
+  end
+
   def insert_metric(tid, %Metrics.Counter{} = metric, _value, %{} = tags) do
     key = {metric, tags, :erlang.system_info(:scheduler_id)}
     :ets.update_counter(tid, key, {2, 1}, {key, 0})

--- a/lib/peep/storage/atomics.ex
+++ b/lib/peep/storage/atomics.ex
@@ -13,7 +13,7 @@ defmodule Peep.Storage.Atomics do
     {bucket_calculator, config} = Peep.Buckets.config(metric)
     num_buckets = bucket_calculator.number_of_buckets(config)
     buckets = :atomics.new(num_buckets, signed: false)
-    sum = :atomics.new(1, signed: false)
+    sum = :atomics.new(1, signed: true)
     above_max = :atomics.new(1, signed: false)
 
     %__MODULE__{

--- a/lib/peep/storage/ets.ex
+++ b/lib/peep/storage/ets.ex
@@ -1,6 +1,6 @@
-defmodule Peep.Storage do
+defmodule Peep.Storage.ETS do
   @moduledoc false
-  alias __MODULE__
+  alias Peep.Storage
   alias Telemetry.Metrics
 
   @spec new() :: :ets.tid()

--- a/lib/peep/storage/ets.ex
+++ b/lib/peep/storage/ets.ex
@@ -3,7 +3,10 @@ defmodule Peep.Storage.ETS do
   alias Peep.Storage
   alias Telemetry.Metrics
 
+  @behaviour Peep.Storage
+
   @spec new() :: :ets.tid()
+  @impl true
   def new() do
     opts = [
       :public,
@@ -18,6 +21,7 @@ defmodule Peep.Storage.ETS do
     :ets.new(__MODULE__, opts)
   end
 
+  @impl true
   def storage_size(tid) do
     %{
       size: :ets.info(tid, :size),
@@ -25,6 +29,7 @@ defmodule Peep.Storage.ETS do
     }
   end
 
+  @impl true
   def insert_metric(tid, %Metrics.Counter{} = metric, _value, %{} = tags) do
     key = {metric, tags, :erlang.system_info(:scheduler_id)}
     :ets.update_counter(tid, key, {2, 1}, {key, 0})
@@ -68,11 +73,13 @@ defmodule Peep.Storage.ETS do
     Storage.Atomics.insert(atomics, value)
   end
 
+  @impl true
   def get_all_metrics(tid) do
     :ets.tab2list(tid)
     |> group_metrics(%{})
   end
 
+  @impl true
   def get_metric(tid, metrics, tags) when is_list(tags),
     do: get_metric(tid, metrics, Map.new(tags))
 

--- a/lib/peep/storage/striped.ex
+++ b/lib/peep/storage/striped.ex
@@ -1,0 +1,196 @@
+defmodule Peep.Storage.Striped do
+  @moduledoc false
+  alias Telemetry.Metrics
+  alias Peep.Storage
+
+  @type tids() :: %{pos_integer() => :ets.tid()}
+
+  @spec new() :: tids()
+  def new() do
+    opts = [
+      :public,
+      read_concurrency: false,
+      write_concurrency: true,
+      decentralized_counters: true
+    ]
+
+    n_schedulers = :erlang.system_info(:schedulers_online)
+    Map.new(1..n_schedulers, fn i -> {i, :ets.new(__MODULE__, opts)} end)
+  end
+
+  def insert_metric(tids, %Metrics.Counter{} = metric, _value, %{} = tags) do
+    tid = get_tid(tids)
+    key = {metric, tags}
+    :ets.update_counter(tid, key, {2, 1}, {key, 0})
+  end
+
+  def insert_metric(tids, %Metrics.Sum{} = metric, value, %{} = tags) do
+    tid = get_tid(tids)
+    key = {metric, tags}
+    :ets.update_counter(tid, key, {2, value}, {key, 0})
+  end
+
+  def insert_metric(tids, %Metrics.LastValue{} = metric, value, %{} = tags) do
+    tid = get_tid(tids)
+    now = System.monotonic_time()
+    key = {metric, tags}
+    :ets.insert(tid, {key, {now, value}})
+  end
+
+  def insert_metric(tids, %Metrics.Distribution{} = metric, value, %{} = tags) do
+    tid = get_tid(tids)
+    key = {metric, tags}
+
+    atomics =
+      case :ets.lookup(tid, key) do
+        [{_key, ref}] ->
+          ref
+
+        [] ->
+          # Race condition: Multiple processes could be attempting
+          # to write to this key. Thankfully, :ets.insert_new/2 will break ties,
+          # and concurrent writers should agree on which :atomics object to
+          # increment.
+          new_atomics = Storage.Atomics.new(metric)
+
+          case :ets.insert_new(tid, {key, new_atomics}) do
+            true ->
+              new_atomics
+
+            false ->
+              [{_key, atomics}] = :ets.lookup(tid, key)
+              atomics
+          end
+      end
+
+    Storage.Atomics.insert(atomics, value)
+  end
+
+  defp get_tid(tids) do
+    scheduler_id = :erlang.system_info(:scheduler_id)
+    %{^scheduler_id => tid} = tids
+    tid
+  end
+
+  def get_metric(tids, metrics, tags) when is_list(tags),
+    do: get_metric(tids, metrics, Map.new(tags))
+
+  def get_metric(tids, %Metrics.Counter{} = metric, tags) do
+    key = {metric, tags}
+
+    for tid <- Map.values(tids), reduce: 0 do
+      acc ->
+        case :ets.lookup(tid, key) do
+          [] -> acc
+          [{_, value}] -> acc + value
+        end
+    end
+  end
+
+  def get_metric(tids, %Metrics.Sum{} = metric, tags) do
+    key = {metric, tags}
+
+    for tid <- Map.values(tids), reduce: 0 do
+      acc ->
+        case :ets.lookup(tid, key) do
+          [] -> acc
+          [{_, value}] -> acc + value
+        end
+    end
+  end
+
+  def get_metric(tids, %Metrics.LastValue{} = metric, tags) do
+    key = {metric, tags}
+
+    {_ts, value} =
+      for tid <- Map.values(tids), reduce: nil do
+        acc ->
+          case :ets.lookup(tid, key) do
+            [] ->
+              acc
+
+            [{_, {_, _} = b}] ->
+              if acc do
+                max(acc, b)
+              else
+                b
+              end
+          end
+      end
+
+    value
+  end
+
+  def get_metric(tids, %Metrics.Distribution{} = metric, tags) do
+    key = {metric, tags}
+
+    merge_fun = fn _k, v1, v2 -> v1 + v2 end
+
+    for tid <- Map.values(tids), reduce: nil do
+      acc ->
+        case :ets.lookup(tid, key) do
+          [] ->
+            acc
+
+          [{_key, atomics}] ->
+            values = Storage.Atomics.values(atomics)
+
+            if acc do
+              Map.merge(acc, values, merge_fun)
+            else
+              values
+            end
+        end
+    end
+  end
+
+  def get_all_metrics(tids) do
+    acc = get_all_metrics(Map.values(tids), %{})
+    remove_timestamps_from_last_values(acc)
+  end
+
+  defp get_all_metrics([], acc), do: acc
+
+  defp get_all_metrics([tid | rest], acc) do
+    acc = add_metrics(:ets.tab2list(tid), acc)
+    get_all_metrics(rest, acc)
+  end
+
+  defp add_metrics([], acc), do: acc
+
+  defp add_metrics([metric | rest], acc) do
+    acc2 = add_metric(metric, acc)
+    add_metrics(rest, acc2)
+  end
+
+  defp add_metric({{%Metrics.Counter{} = metric, tags}, value}, acc) do
+    path = [Access.key(metric, %{}), Access.key(tags, 0)]
+    update_in(acc, path, &(&1 + value))
+  end
+
+  defp add_metric({{%Metrics.Sum{} = metric, tags}, value}, acc) do
+    path = [Access.key(metric, %{}), Access.key(tags, 0)]
+    update_in(acc, path, &(&1 + value))
+  end
+
+  defp add_metric({{%Metrics.LastValue{} = metric, tags}, {_, _} = a}, acc) do
+    path = [
+      Access.key(:last_values, %{}),
+      Access.key(metric, %{}),
+      Access.key(tags, a)
+    ]
+
+    update_in(acc, path, fn {_, _} = b -> max(a, b) end)
+  end
+
+  defp remove_timestamps_from_last_values(%{last_values: lvs} = metrics) do
+    last_value_metrics =
+      Map.new(lvs, fn {key, {_ts, value}} -> {key, value} end)
+
+    metrics
+    |> Map.delete(:last_values)
+    |> Map.merge(last_value_metrics)
+  end
+
+  defp remove_timestamps_from_last_values(metrics), do: metrics
+end

--- a/lib/peep/storage/striped.ex
+++ b/lib/peep/storage/striped.ex
@@ -18,6 +18,16 @@ defmodule Peep.Storage.Striped do
     Map.new(1..n_schedulers, fn i -> {i, :ets.new(__MODULE__, opts)} end)
   end
 
+  def storage_size(tids) do
+    size = Enum.reduce(tids, 0, fn {_, tid}, acc -> acc + :ets.info(tid, :size) end)
+    memory = Enum.reduce(tids, 0, fn {_, tid}, acc -> acc + :ets.info(tid, :memory) end)
+
+    %{
+      size: size,
+      memory: memory * :erlang.system_info(:wordsize)
+    }
+  end
+
   def insert_metric(tids, %Metrics.Counter{} = metric, _value, %{} = tags) do
     tid = get_tid(tids)
     key = {metric, tags}

--- a/lib/peep/storage/striped.ex
+++ b/lib/peep/storage/striped.ex
@@ -3,9 +3,12 @@ defmodule Peep.Storage.Striped do
   alias Telemetry.Metrics
   alias Peep.Storage
 
+  @behaviour Peep.Storage
+
   @type tids() :: %{pos_integer() => :ets.tid()}
 
   @spec new() :: tids()
+  @impl true
   def new() do
     opts = [
       :public,
@@ -18,6 +21,7 @@ defmodule Peep.Storage.Striped do
     Map.new(1..n_schedulers, fn i -> {i, :ets.new(__MODULE__, opts)} end)
   end
 
+  @impl true
   def storage_size(tids) do
     size = Enum.reduce(tids, 0, fn {_, tid}, acc -> acc + :ets.info(tid, :size) end)
     memory = Enum.reduce(tids, 0, fn {_, tid}, acc -> acc + :ets.info(tid, :memory) end)
@@ -28,6 +32,7 @@ defmodule Peep.Storage.Striped do
     }
   end
 
+  @impl true
   def insert_metric(tids, %Metrics.Counter{} = metric, _value, %{} = tags) do
     tid = get_tid(tids)
     key = {metric, tags}
@@ -82,6 +87,7 @@ defmodule Peep.Storage.Striped do
     tid
   end
 
+  @impl true
   def get_metric(tids, metrics, tags) when is_list(tags),
     do: get_metric(tids, metrics, Map.new(tags))
 
@@ -154,6 +160,7 @@ defmodule Peep.Storage.Striped do
     end
   end
 
+  @impl true
   def get_all_metrics(tids) do
     acc = get_all_metrics(Map.values(tids), %{})
     remove_timestamps_from_last_values(acc)

--- a/test/peep_test.exs
+++ b/test/peep_test.exs
@@ -4,7 +4,6 @@ defmodule PeepTest do
 
   doctest Peep
 
-  alias Peep.Storage
   alias Telemetry.Metrics
 
   test "a worker can be started" do
@@ -73,12 +72,10 @@ defmodule PeepTest do
     :telemetry.execute([:gauge], %{value: 10})
     :telemetry.execute([:dist], %{value: 15})
 
-    {:ok, tid} = Peep.Persistent.tid(name)
-
-    assert Storage.get_metric(tid, counter, tags) == 1
-    assert Storage.get_metric(tid, sum, tags) == 5
-    assert Storage.get_metric(tid, last_value, tags) == 10
-    assert Storage.get_metric(tid, distribution, tags).sum == 15
+    assert Peep.get_metric(name, counter, tags) == 1
+    assert Peep.get_metric(name, sum, tags) == 5
+    assert Peep.get_metric(name, last_value, tags) == 10
+    assert Peep.get_metric(name, distribution, tags).sum == 15
   end
 
   test "Peep process name can be used with Peep.Storage" do

--- a/test/peep_test.exs
+++ b/test/peep_test.exs
@@ -73,10 +73,12 @@ defmodule PeepTest do
     :telemetry.execute([:gauge], %{value: 10})
     :telemetry.execute([:dist], %{value: 15})
 
-    assert Storage.get_metric(name, counter, tags) == 1
-    assert Storage.get_metric(name, sum, tags) == 5
-    assert Storage.get_metric(name, last_value, tags) == 10
-    assert Storage.get_metric(name, distribution, tags).sum == 15
+    {:ok, tid} = Peep.Persistent.tid(name)
+
+    assert Storage.get_metric(tid, counter, tags) == 1
+    assert Storage.get_metric(tid, sum, tags) == 5
+    assert Storage.get_metric(tid, last_value, tags) == 10
+    assert Storage.get_metric(tid, distribution, tags).sum == 15
   end
 
   test "Peep process name can be used with Peep.Storage" do

--- a/test/prometheus_test.exs
+++ b/test/prometheus_test.exs
@@ -1,301 +1,373 @@
 defmodule PrometheusTest do
   use ExUnit.Case, async: true
 
-  alias Peep.{Prometheus, Storage}
+  alias Peep.Prometheus
   alias Telemetry.Metrics
 
   alias Peep.Support.StorageCounter
 
-  test "counter formatting" do
-    tid = Storage.new(StorageCounter.fresh_id())
-    counter = Metrics.counter("prometheus.test.counter", description: "a counter")
+  @impls [:default, :striped]
 
-    Storage.insert_metric(tid, counter, 1, %{foo: :bar, baz: "quux"})
+  for impl <- @impls do
+    test "#{impl} - counter formatting" do
+      counter = Metrics.counter("prometheus.test.counter", description: "a counter")
+      name = StorageCounter.fresh_id()
 
-    expected = [
-      "# HELP prometheus_test_counter a counter",
-      "# TYPE prometheus_test_counter counter",
-      ~s(prometheus_test_counter{baz="quux",foo="bar"} 1)
-    ]
-
-    assert export(tid) == lines_to_string(expected)
-  end
-
-  describe "sum" do
-    test "formatting" do
-      tid = Storage.new(StorageCounter.fresh_id())
-      sum = Metrics.sum("prometheus.test.sum", description: "a sum")
-
-      Storage.insert_metric(tid, sum, 5, %{foo: :bar, baz: "quux"})
-      Storage.insert_metric(tid, sum, 3, %{foo: :bar, baz: "quux"})
-
-      expected = [
-        "# HELP prometheus_test_sum a sum",
-        "# TYPE prometheus_test_sum counter",
-        ~s(prometheus_test_sum{baz="quux",foo="bar"} 8)
+      opts = [
+        name: name,
+        metrics: [counter],
+        storage: unquote(impl)
       ]
 
-      assert export(tid) == lines_to_string(expected)
-    end
+      {:ok, _pid} = Peep.start_link(opts)
 
-    test "custom type" do
-      tid = Storage.new(StorageCounter.fresh_id())
-
-      sum =
-        Metrics.sum("prometheus.test.sum",
-          description: "a sum",
-          reporter_options: [prometheus_type: "gauge"]
-        )
-
-      Storage.insert_metric(tid, sum, 5, %{foo: :bar, baz: "quux"})
-      Storage.insert_metric(tid, sum, 3, %{foo: :bar, baz: "quux"})
+      Peep.insert_metric(name, counter, 1, %{foo: :bar, baz: "quux"})
 
       expected = [
-        "# HELP prometheus_test_sum a sum",
-        "# TYPE prometheus_test_sum gauge",
-        ~s(prometheus_test_sum{baz="quux",foo="bar"} 8)
+        "# HELP prometheus_test_counter a counter",
+        "# TYPE prometheus_test_counter counter",
+        ~s(prometheus_test_counter{baz="quux",foo="bar"} 1)
       ]
 
-      assert export(tid) == lines_to_string(expected)
-    end
-  end
-
-  describe "last_value" do
-    test "formatting" do
-      tid = Storage.new(StorageCounter.fresh_id())
-      last_value = Metrics.last_value("prometheus.test.gauge", description: "a last_value")
-
-      Storage.insert_metric(tid, last_value, 5, %{blee: :bloo, flee: "floo"})
-
-      expected = [
-        "# HELP prometheus_test_gauge a last_value",
-        "# TYPE prometheus_test_gauge gauge",
-        ~s(prometheus_test_gauge{blee="bloo",flee="floo"} 5)
-      ]
-
-      assert export(tid) == lines_to_string(expected)
+      assert export(name) == lines_to_string(expected)
     end
 
-    test "custom type" do
-      tid = Storage.new(StorageCounter.fresh_id())
+    describe "#{impl} - sum" do
+      test "sum formatting" do
+        name = StorageCounter.fresh_id()
+        sum = Metrics.sum("prometheus.test.sum", description: "a sum")
 
-      last_value =
-        Metrics.last_value("prometheus.test.gauge",
-          description: "a last_value",
-          reporter_options: [prometheus_type: :sum]
-        )
-
-      Storage.insert_metric(tid, last_value, 5, %{blee: :bloo, flee: "floo"})
-
-      expected = [
-        "# HELP prometheus_test_gauge a last_value",
-        "# TYPE prometheus_test_gauge sum",
-        ~s(prometheus_test_gauge{blee="bloo",flee="floo"} 5)
-      ]
-
-      assert export(tid) == lines_to_string(expected)
-    end
-  end
-
-  test "dist formatting" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    dist =
-      Metrics.distribution("prometheus.test.distribution",
-        description: "a distribution",
-        reporter_options: [max_value: 1000]
-      )
-
-    expected = []
-    assert export(tid) == lines_to_string(expected)
-
-    Storage.insert_metric(tid, dist, 1, %{glee: :gloo})
-
-    expected = [
-      "# HELP prometheus_test_distribution a distribution",
-      "# TYPE prometheus_test_distribution histogram",
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.222222"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.493827"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.825789"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="2.23152"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="2.727413"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="3.333505"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="4.074283"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="4.97968"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="6.086275"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="7.438781"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="9.091843"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="11.112253"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="13.581642"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="16.599785"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="20.288626"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="24.79721"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="30.307701"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="37.042745"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="45.274466"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="55.335459"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="67.632227"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="82.661611"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="101.030858"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="123.48216"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="150.92264"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="184.461004"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="225.452339"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="275.552858"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="336.786827"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="411.628344"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="503.101309"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="614.9016"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="751.5464"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="918.556711"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1122.680424"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="+Inf"} 1),
-      ~s(prometheus_test_distribution_sum{glee="gloo"} 1),
-      ~s(prometheus_test_distribution_count{glee="gloo"} 1)
-    ]
-
-    assert export(tid) == lines_to_string(expected)
-
-    for i <- 2..2000 do
-      Storage.insert_metric(tid, dist, i, %{glee: :gloo})
-    end
-
-    expected = [
-      "# HELP prometheus_test_distribution a distribution",
-      "# TYPE prometheus_test_distribution histogram",
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.222222"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.493827"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.825789"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="2.23152"} 2),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="2.727413"} 2),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="3.333505"} 3),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="4.074283"} 4),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="4.97968"} 4),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="6.086275"} 6),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="7.438781"} 7),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="9.091843"} 9),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="11.112253"} 11),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="13.581642"} 13),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="16.599785"} 16),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="20.288626"} 20),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="24.79721"} 24),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="30.307701"} 30),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="37.042745"} 37),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="45.274466"} 45),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="55.335459"} 55),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="67.632227"} 67),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="82.661611"} 82),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="101.030858"} 101),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="123.48216"} 123),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="150.92264"} 150),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="184.461004"} 184),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="225.452339"} 225),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="275.552858"} 275),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="336.786827"} 336),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="411.628344"} 411),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="503.101309"} 503),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="614.9016"} 614),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="751.5464"} 751),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="918.556711"} 918),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1122.680424"} 1122),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="+Inf"} 2000),
-      ~s(prometheus_test_distribution_sum{glee="gloo"} 2001000),
-      ~s(prometheus_test_distribution_count{glee="gloo"} 2000)
-    ]
-
-    assert export(tid) == lines_to_string(expected)
-  end
-
-  test "dist formatting pow10" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    dist =
-      Metrics.distribution("prometheus.test.distribution",
-        description: "a distribution",
-        reporter_options: [
-          max_value: 1000,
-          peep_bucket_calculator: Peep.Buckets.PowersOfTen
+        opts = [
+          name: name,
+          metrics: [sum],
+          storage: unquote(impl)
         ]
-      )
 
-    expected = []
-    assert export(tid) == lines_to_string(expected)
+        {:ok, _pid} = Peep.start_link(opts)
 
-    Storage.insert_metric(tid, dist, 1, %{glee: :gloo})
+        Peep.insert_metric(name, sum, 5, %{foo: :bar, baz: "quux"})
+        Peep.insert_metric(name, sum, 3, %{foo: :bar, baz: "quux"})
 
-    expected = [
-      "# HELP prometheus_test_distribution a distribution",
-      "# TYPE prometheus_test_distribution histogram",
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="10.0"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="100.0"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e3"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e4"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e5"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e6"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e7"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e8"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e9"} 1),
-      ~s(prometheus_test_distribution_bucket{glee="gloo",le="+Inf"} 1),
-      ~s(prometheus_test_distribution_sum{glee="gloo"} 1),
-      ~s(prometheus_test_distribution_count{glee="gloo"} 1)
-    ]
+        expected = [
+          "# HELP prometheus_test_sum a sum",
+          "# TYPE prometheus_test_sum counter",
+          ~s(prometheus_test_sum{baz="quux",foo="bar"} 8)
+        ]
 
-    assert export(tid) == lines_to_string(expected)
+        assert export(name) == lines_to_string(expected)
+      end
 
-    for i <- 2..2000 do
-      Storage.insert_metric(tid, dist, i, %{glee: :gloo})
+      test "custom type" do
+        name = StorageCounter.fresh_id()
+
+        sum =
+          Metrics.sum("prometheus.test.sum",
+            description: "a sum",
+            reporter_options: [prometheus_type: "gauge"]
+          )
+
+        opts = [
+          name: name,
+          metrics: [sum],
+          storage: unquote(impl)
+        ]
+
+        {:ok, _pid} = Peep.start_link(opts)
+
+        Peep.insert_metric(name, sum, 5, %{foo: :bar, baz: "quux"})
+        Peep.insert_metric(name, sum, 3, %{foo: :bar, baz: "quux"})
+
+        expected = [
+          "# HELP prometheus_test_sum a sum",
+          "# TYPE prometheus_test_sum gauge",
+          ~s(prometheus_test_sum{baz="quux",foo="bar"} 8)
+        ]
+
+        assert export(name) == lines_to_string(expected)
+      end
     end
 
-    expected =
-      [
+    describe "#{impl} - last_value" do
+      test "formatting" do
+        name = StorageCounter.fresh_id()
+        last_value = Metrics.last_value("prometheus.test.gauge", description: "a last_value")
+
+        opts = [
+          name: name,
+          metrics: [last_value],
+          storage: unquote(impl)
+        ]
+
+        {:ok, _pid} = Peep.start_link(opts)
+
+        Peep.insert_metric(name, last_value, 5, %{blee: :bloo, flee: "floo"})
+
+        expected = [
+          "# HELP prometheus_test_gauge a last_value",
+          "# TYPE prometheus_test_gauge gauge",
+          ~s(prometheus_test_gauge{blee="bloo",flee="floo"} 5)
+        ]
+
+        assert export(name) == lines_to_string(expected)
+      end
+
+      test "custom type" do
+        name = StorageCounter.fresh_id()
+
+        last_value =
+          Metrics.last_value("prometheus.test.gauge",
+            description: "a last_value",
+            reporter_options: [prometheus_type: :sum]
+          )
+
+        opts = [
+          name: name,
+          metrics: [last_value],
+          storage: unquote(impl)
+        ]
+
+        {:ok, _pid} = Peep.start_link(opts)
+
+        Peep.insert_metric(name, last_value, 5, %{blee: :bloo, flee: "floo"})
+
+        expected = [
+          "# HELP prometheus_test_gauge a last_value",
+          "# TYPE prometheus_test_gauge sum",
+          ~s(prometheus_test_gauge{blee="bloo",flee="floo"} 5)
+        ]
+
+        assert export(name) == lines_to_string(expected)
+      end
+    end
+
+    test "#{impl} - dist formatting" do
+      name = StorageCounter.fresh_id()
+
+      dist =
+        Metrics.distribution("prometheus.test.distribution",
+          description: "a distribution",
+          reporter_options: [max_value: 1000]
+        )
+
+      opts = [
+        name: name,
+        metrics: [dist],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      expected = []
+      assert export(name) == lines_to_string(expected)
+
+      Peep.insert_metric(name, dist, 1, %{glee: :gloo})
+
+      expected = [
         "# HELP prometheus_test_distribution a distribution",
         "# TYPE prometheus_test_distribution histogram",
-        ~s(prometheus_test_distribution_bucket{glee="gloo",le="10.0"} 9),
-        ~s(prometheus_test_distribution_bucket{glee="gloo",le="100.0"} 99),
-        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e3"} 999),
-        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e4"} 2000),
-        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e5"} 2000),
-        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e6"} 2000),
-        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e7"} 2000),
-        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e8"} 2000),
-        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e9"} 2000),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.222222"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.493827"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.825789"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="2.23152"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="2.727413"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="3.333505"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="4.074283"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="4.97968"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="6.086275"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="7.438781"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="9.091843"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="11.112253"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="13.581642"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="16.599785"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="20.288626"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="24.79721"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="30.307701"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="37.042745"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="45.274466"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="55.335459"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="67.632227"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="82.661611"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="101.030858"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="123.48216"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="150.92264"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="184.461004"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="225.452339"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="275.552858"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="336.786827"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="411.628344"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="503.101309"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="614.9016"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="751.5464"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="918.556711"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1122.680424"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="+Inf"} 1),
+        ~s(prometheus_test_distribution_sum{glee="gloo"} 1),
+        ~s(prometheus_test_distribution_count{glee="gloo"} 1)
+      ]
+
+      assert export(name) == lines_to_string(expected)
+
+      for i <- 2..2000 do
+        Peep.insert_metric(name, dist, i, %{glee: :gloo})
+      end
+
+      expected = [
+        "# HELP prometheus_test_distribution a distribution",
+        "# TYPE prometheus_test_distribution histogram",
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.222222"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.493827"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.825789"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="2.23152"} 2),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="2.727413"} 2),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="3.333505"} 3),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="4.074283"} 4),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="4.97968"} 4),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="6.086275"} 6),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="7.438781"} 7),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="9.091843"} 9),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="11.112253"} 11),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="13.581642"} 13),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="16.599785"} 16),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="20.288626"} 20),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="24.79721"} 24),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="30.307701"} 30),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="37.042745"} 37),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="45.274466"} 45),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="55.335459"} 55),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="67.632227"} 67),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="82.661611"} 82),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="101.030858"} 101),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="123.48216"} 123),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="150.92264"} 150),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="184.461004"} 184),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="225.452339"} 225),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="275.552858"} 275),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="336.786827"} 336),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="411.628344"} 411),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="503.101309"} 503),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="614.9016"} 614),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="751.5464"} 751),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="918.556711"} 918),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1122.680424"} 1122),
         ~s(prometheus_test_distribution_bucket{glee="gloo",le="+Inf"} 2000),
         ~s(prometheus_test_distribution_sum{glee="gloo"} 2001000),
         ~s(prometheus_test_distribution_count{glee="gloo"} 2000)
       ]
 
-    assert export(tid) == lines_to_string(expected)
+      assert export(name) == lines_to_string(expected)
+    end
+
+    test "#{impl} - dist formatting pow10" do
+      name = StorageCounter.fresh_id()
+
+      dist =
+        Metrics.distribution("prometheus.test.distribution",
+          description: "a distribution",
+          reporter_options: [
+            max_value: 1000,
+            peep_bucket_calculator: Peep.Buckets.PowersOfTen
+          ]
+        )
+
+      opts = [
+        name: name,
+        metrics: [dist],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      expected = []
+      assert export(name) == lines_to_string(expected)
+
+      Peep.insert_metric(name, dist, 1, %{glee: :gloo})
+
+      expected = [
+        "# HELP prometheus_test_distribution a distribution",
+        "# TYPE prometheus_test_distribution histogram",
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="10.0"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="100.0"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e3"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e4"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e5"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e6"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e7"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e8"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e9"} 1),
+        ~s(prometheus_test_distribution_bucket{glee="gloo",le="+Inf"} 1),
+        ~s(prometheus_test_distribution_sum{glee="gloo"} 1),
+        ~s(prometheus_test_distribution_count{glee="gloo"} 1)
+      ]
+
+      assert export(name) == lines_to_string(expected)
+
+      f = fn ->
+        for i <- 1..2000 do
+          Peep.insert_metric(name, dist, i, %{glee: :gloo})
+        end
+      end
+
+      1..20 |> Enum.map(fn _ -> Task.async(f) end) |> Task.await_many()
+
+      expected =
+        [
+          "# HELP prometheus_test_distribution a distribution",
+          "# TYPE prometheus_test_distribution histogram",
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="10.0"} 181),
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="100.0"} 1981),
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e3"} 19981),
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e4"} 40001),
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e5"} 40001),
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e6"} 40001),
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e7"} 40001),
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e8"} 40001),
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="1.0e9"} 40001),
+          ~s(prometheus_test_distribution_bucket{glee="gloo",le="+Inf"} 40001),
+          ~s(prometheus_test_distribution_sum{glee="gloo"} 40020001),
+          ~s(prometheus_test_distribution_count{glee="gloo"} 40001)
+        ]
+
+      assert export(name) == lines_to_string(expected)
+    end
+
+    test "#{impl} - non-number values" do
+      name = StorageCounter.fresh_id()
+
+      last_value =
+        Metrics.last_value(
+          "prometheus.test.gauge",
+          description: "a last_value",
+          tags: [:from]
+        )
+
+      opts = [
+        name: name,
+        metrics: [last_value],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      Peep.insert_metric(name, last_value, true, %{from: true})
+      Peep.insert_metric(name, last_value, false, %{from: false})
+      Peep.insert_metric(name, last_value, nil, %{from: nil})
+
+      expected = [
+        "# HELP prometheus_test_gauge a last_value",
+        "# TYPE prometheus_test_gauge gauge",
+        ~s(prometheus_test_gauge{from="false"} 0),
+        ~s(prometheus_test_gauge{from="nil"} 0),
+        ~s(prometheus_test_gauge{from="true"} 1)
+      ]
+
+      assert export(name) == lines_to_string(expected)
+    end
   end
 
-  test "non-number values" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    last_value =
-      Metrics.last_value(
-        "prometheus.test.gauge",
-        description: "a last_value",
-        tags: [:from]
-      )
-
-    Storage.insert_metric(tid, last_value, true, %{from: true})
-    Storage.insert_metric(tid, last_value, false, %{from: false})
-    Storage.insert_metric(tid, last_value, nil, %{from: nil})
-
-    expected = [
-      "# HELP prometheus_test_gauge a last_value",
-      "# TYPE prometheus_test_gauge gauge",
-      ~s(prometheus_test_gauge{from="false"} 0),
-      ~s(prometheus_test_gauge{from="nil"} 0),
-      ~s(prometheus_test_gauge{from="true"} 1)
-    ]
-
-    assert export(tid) == lines_to_string(expected)
-  end
-
-  defp export(tid) do
-    Storage.get_all_metrics(tid)
+  defp export(name) do
+    Peep.get_all_metrics(name)
     |> Prometheus.export()
     |> IO.iodata_to_binary()
   end

--- a/test/statsd_cache_test.exs
+++ b/test/statsd_cache_test.exs
@@ -1,97 +1,132 @@
 defmodule StatsdCacheTest do
   use ExUnit.Case
 
-  alias Peep.Storage
   alias Peep.Statsd.Cache
   alias Telemetry.Metrics
 
   alias Peep.Support.StorageCounter
 
-  test "a counter with no increments is omitted from delta" do
-    tid = Storage.new(StorageCounter.fresh_id())
+  @impls [:default, :striped]
 
-    counter = Metrics.counter("cache.test.counter")
+  for impl <- @impls do
+    test "#{impl} - a counter with no increments is omitted from delta" do
+      name = StorageCounter.fresh_id()
 
-    Storage.insert_metric(tid, counter, 1, %{})
+      counter = Metrics.counter("cache.test.counter")
 
-    {delta_one, cache_one} = calculate_deltas_and_replacement(cache_of(tid), Cache.new([]))
+      opts = [
+        name: name,
+        metrics: [counter],
+        storage: unquote(impl)
+      ]
 
-    assert Map.values(delta_one) == [1]
+      {:ok, _pid} = Peep.start_link(opts)
 
-    {delta_two, cache_two} = calculate_deltas_and_replacement(cache_of(tid), cache_one)
+      Peep.insert_metric(name, counter, 1, %{})
 
-    assert Map.values(delta_two) == []
+      {delta_one, cache_one} = calculate_deltas_and_replacement(cache_of(name), Cache.new([]))
 
-    Storage.insert_metric(tid, counter, 1, %{})
-    {delta_three, _cache_three} = calculate_deltas_and_replacement(cache_of(tid), cache_two)
+      assert Map.values(delta_one) == [1]
 
-    assert Map.values(delta_three) == [1]
+      {delta_two, cache_two} = calculate_deltas_and_replacement(cache_of(name), cache_one)
+
+      assert Map.values(delta_two) == []
+
+      Peep.insert_metric(name, counter, 1, %{})
+      {delta_three, _cache_three} = calculate_deltas_and_replacement(cache_of(name), cache_two)
+
+      assert Map.values(delta_three) == [1]
+    end
+
+    test "#{impl} - a sum with no increments is omitted from delta" do
+      name = StorageCounter.fresh_id()
+
+      sum = Metrics.sum("cache.test.counter")
+
+      opts = [
+        name: name,
+        metrics: [sum],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      Peep.insert_metric(name, sum, 10, %{})
+
+      {delta_one, cache_one} = calculate_deltas_and_replacement(cache_of(name), Cache.new([]))
+
+      assert Map.values(delta_one) == [10]
+
+      {delta_two, cache_two} = calculate_deltas_and_replacement(cache_of(name), cache_one)
+
+      assert Map.values(delta_two) == []
+
+      Peep.insert_metric(name, sum, 10, %{})
+      {delta_three, _cache_three} = calculate_deltas_and_replacement(cache_of(name), cache_two)
+
+      assert Map.values(delta_three) == [10]
+    end
+
+    test "#{impl} - a distribution with no samples is omitted from delta" do
+      name = StorageCounter.fresh_id()
+
+      dist = Metrics.distribution("cache.test.dist", reporter_options: [max_value: 1000])
+
+      opts = [
+        name: name,
+        metrics: [dist],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      Peep.insert_metric(name, dist, 500, %{})
+      Peep.insert_metric(name, dist, 500, %{})
+      Peep.insert_metric(name, dist, 500, %{})
+
+      {delta_one, cache_one} = calculate_deltas_and_replacement(cache_of(name), Cache.new([]))
+
+      assert Map.values(delta_one) == [3]
+
+      {delta_two, cache_two} = calculate_deltas_and_replacement(cache_of(name), cache_one)
+
+      assert Map.values(delta_two) == []
+
+      Peep.insert_metric(name, dist, 500, %{})
+      Peep.insert_metric(name, dist, 500, %{})
+      Peep.insert_metric(name, dist, 1000, %{})
+      {delta_three, _cache_three} = calculate_deltas_and_replacement(cache_of(name), cache_two)
+
+      assert Map.values(delta_three) |> Enum.sort() == [1, 2]
+    end
+
+    test "#{impl} - a last_value with no changes is included in deltas" do
+      name = StorageCounter.fresh_id()
+
+      last_value = Metrics.last_value("cache.test.gauge")
+
+      opts = [
+        name: name,
+        metrics: [last_value],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      Peep.insert_metric(name, last_value, 10, %{})
+
+      {delta_one, cache_one} = calculate_deltas_and_replacement(cache_of(name), Cache.new([]))
+
+      assert Map.values(delta_one) == [10]
+
+      {delta_two, _cache_two} = calculate_deltas_and_replacement(cache_of(name), cache_one)
+
+      assert Map.values(delta_two) == [10]
+    end
   end
 
-  test "a sum with no increments is omitted from delta" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    sum = Metrics.sum("cache.test.counter")
-
-    Storage.insert_metric(tid, sum, 10, %{})
-
-    {delta_one, cache_one} = calculate_deltas_and_replacement(cache_of(tid), Cache.new([]))
-
-    assert Map.values(delta_one) == [10]
-
-    {delta_two, cache_two} = calculate_deltas_and_replacement(cache_of(tid), cache_one)
-
-    assert Map.values(delta_two) == []
-
-    Storage.insert_metric(tid, sum, 10, %{})
-    {delta_three, _cache_three} = calculate_deltas_and_replacement(cache_of(tid), cache_two)
-
-    assert Map.values(delta_three) == [10]
-  end
-
-  test "a distribution with no samples is omitted from delta" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    dist = Metrics.distribution("cache.test.dist", reporter_options: [max_value: 1000])
-
-    Storage.insert_metric(tid, dist, 500, %{})
-    Storage.insert_metric(tid, dist, 500, %{})
-    Storage.insert_metric(tid, dist, 500, %{})
-
-    {delta_one, cache_one} = calculate_deltas_and_replacement(cache_of(tid), Cache.new([]))
-
-    assert Map.values(delta_one) == [3]
-
-    {delta_two, cache_two} = calculate_deltas_and_replacement(cache_of(tid), cache_one)
-
-    assert Map.values(delta_two) == []
-
-    Storage.insert_metric(tid, dist, 500, %{})
-    Storage.insert_metric(tid, dist, 500, %{})
-    Storage.insert_metric(tid, dist, 1000, %{})
-    {delta_three, _cache_three} = calculate_deltas_and_replacement(cache_of(tid), cache_two)
-
-    assert Map.values(delta_three) |> Enum.sort() == [1, 2]
-  end
-
-  test "a last_value with no changes is included in deltas" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    last_value = Metrics.last_value("cache.test.gauge")
-
-    Storage.insert_metric(tid, last_value, 10, %{})
-
-    {delta_one, cache_one} = calculate_deltas_and_replacement(cache_of(tid), Cache.new([]))
-
-    assert Map.values(delta_one) == [10]
-
-    {delta_two, _cache_two} = calculate_deltas_and_replacement(cache_of(tid), cache_one)
-
-    assert Map.values(delta_two) == [10]
-  end
-
-  defp cache_of(tid) do
-    Storage.get_all_metrics(tid)
+  defp cache_of(name) do
+    Peep.get_all_metrics(name)
     |> Cache.new()
   end
 

--- a/test/statsd_test.exs
+++ b/test/statsd_test.exs
@@ -1,248 +1,308 @@
 defmodule StatsdTest do
   use ExUnit.Case
 
-  alias Peep.{Statsd, Storage}
+  alias Peep.Statsd
   alias Telemetry.Metrics
 
   alias Peep.Support.StorageCounter
 
-  test "a counter can be formatted" do
-    tid = Storage.new(StorageCounter.fresh_id())
+  @impls [:default, :striped]
 
-    counter = Metrics.counter("statsd.test.counter")
+  for impl <- @impls do
+    test "#{impl} - a counter can be formatted" do
+      name = StorageCounter.fresh_id()
 
-    for i <- 1..10 do
-      Storage.insert_metric(tid, counter, 1, %{})
+      counter = Metrics.counter("statsd.test.counter")
 
-      if rem(i, 2) == 0 do
-        Storage.insert_metric(tid, counter, 1, %{even: true})
-      end
-    end
-
-    expected = ["statsd.test.counter:10|c", "statsd.test.counter:5|c|#even:true"]
-    assert parse_packets(get_statsd_packets(tid)) == parse_packets(expected)
-  end
-
-  test "a sum can be formatted" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    sum = Metrics.sum("statsd.test.sum")
-
-    for i <- 1..10 do
-      Storage.insert_metric(tid, sum, 1, %{})
-
-      if rem(i, 2) == 0 do
-        Storage.insert_metric(tid, sum, 1, %{even: true})
-      end
-    end
-
-    expected = ["statsd.test.sum:10|c", "statsd.test.sum:5|c|#even:true"]
-    assert parse_packets(get_statsd_packets(tid)) == parse_packets(expected)
-  end
-
-  test "a last_value can be formatted" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    last_value = Metrics.last_value("statsd.test.gauge")
-
-    for i <- 1..10 do
-      Storage.insert_metric(tid, last_value, i, %{})
-
-      if rem(i, 2) == 1 do
-        Storage.insert_metric(tid, last_value, i, %{odd: true})
-      end
-    end
-
-    expected = ["statsd.test.gauge:10|g", "statsd.test.gauge:9|g|#odd:true"]
-    assert parse_packets(get_statsd_packets(tid)) == parse_packets(expected)
-  end
-
-  test "a distribution can be formatted (standard)" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    dist = Metrics.distribution("statsd.test.dist", reporter_options: [max_value: 1000])
-
-    for i <- 1..1000 do
-      Storage.insert_metric(tid, dist, i, %{})
-
-      if rem(i, 100) == 0 do
-        Storage.insert_metric(tid, dist, i, %{foo: :bar})
-      end
-    end
-
-    expected = [
-      "statsd.test.dist:1.0|ms|@1.0",
-      "statsd.test.dist:2.23152|ms|@1.0",
-      "statsd.test.dist:3.333505|ms|@1.0",
-      "statsd.test.dist:4.074283|ms|@1.0",
-      "statsd.test.dist:6.086275|ms|@0.5",
-      "statsd.test.dist:7.438781|ms|@1.0",
-      "statsd.test.dist:9.091843|ms|@0.5",
-      "statsd.test.dist:11.112253|ms|@0.5",
-      "statsd.test.dist:13.581642|ms|@0.5",
-      "statsd.test.dist:16.599785|ms|@0.333333",
-      "statsd.test.dist:20.288626|ms|@0.25",
-      "statsd.test.dist:24.79721|ms|@0.25",
-      "statsd.test.dist:30.307701|ms|@0.166667",
-      "statsd.test.dist:37.042745|ms|@0.142857",
-      "statsd.test.dist:45.274466|ms|@0.125",
-      "statsd.test.dist:55.335459|ms|@0.1",
-      "statsd.test.dist:67.632227|ms|@0.083333",
-      "statsd.test.dist:82.661611|ms|@0.066667",
-      "statsd.test.dist:101.030858|ms|@0.052632",
-      "statsd.test.dist:123.48216|ms|@0.045455",
-      "statsd.test.dist:150.92264|ms|@0.037037",
-      "statsd.test.dist:184.461004|ms|@0.029412",
-      "statsd.test.dist:225.452339|ms|@0.02439",
-      "statsd.test.dist:275.552858|ms|@0.02",
-      "statsd.test.dist:336.786827|ms|@0.016393",
-      "statsd.test.dist:411.628344|ms|@0.013333",
-      "statsd.test.dist:503.101309|ms|@0.01087",
-      "statsd.test.dist:614.9016|ms|@0.009009",
-      "statsd.test.dist:751.5464|ms|@0.007299",
-      "statsd.test.dist:918.556711|ms|@0.005988",
-      "statsd.test.dist:1122.680424|ms|@0.012195",
-      #
-      "statsd.test.dist:101.030858|ms|@1.0|#foo:bar",
-      "statsd.test.dist:225.452339|ms|@1.0|#foo:bar",
-      "statsd.test.dist:336.786827|ms|@1.0|#foo:bar",
-      "statsd.test.dist:411.628344|ms|@1.0|#foo:bar",
-      "statsd.test.dist:503.101309|ms|@1.0|#foo:bar",
-      "statsd.test.dist:614.9016|ms|@1.0|#foo:bar",
-      "statsd.test.dist:751.5464|ms|@1.0|#foo:bar",
-      "statsd.test.dist:918.556711|ms|@0.5|#foo:bar",
-      "statsd.test.dist:1122.680424|ms|@1.0|#foo:bar"
-    ]
-
-    packets = get_statsd_packets(tid, %{formatter: :standard})
-
-    assert parse_packets(packets) == parse_packets(expected)
-  end
-
-  test "a distribution can be formatted (datadog)" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    dist = Metrics.distribution("statsd.test.dist", reporter_options: [max_value: 1000])
-
-    for i <- 1..1000 do
-      Storage.insert_metric(tid, dist, i, %{})
-
-      if rem(i, 100) == 0 do
-        Storage.insert_metric(tid, dist, i, %{foo: :bar})
-      end
-    end
-
-    expected = [
-      "statsd.test.dist:1.0|d|@1.0",
-      "statsd.test.dist:2.23152|d|@1.0",
-      "statsd.test.dist:3.333505|d|@1.0",
-      "statsd.test.dist:4.074283|d|@1.0",
-      "statsd.test.dist:6.086275|d|@0.5",
-      "statsd.test.dist:7.438781|d|@1.0",
-      "statsd.test.dist:9.091843|d|@0.5",
-      "statsd.test.dist:11.112253|d|@0.5",
-      "statsd.test.dist:13.581642|d|@0.5",
-      "statsd.test.dist:16.599785|d|@0.333333",
-      "statsd.test.dist:20.288626|d|@0.25",
-      "statsd.test.dist:24.79721|d|@0.25",
-      "statsd.test.dist:30.307701|d|@0.166667",
-      "statsd.test.dist:37.042745|d|@0.142857",
-      "statsd.test.dist:45.274466|d|@0.125",
-      "statsd.test.dist:55.335459|d|@0.1",
-      "statsd.test.dist:67.632227|d|@0.083333",
-      "statsd.test.dist:82.661611|d|@0.066667",
-      "statsd.test.dist:101.030858|d|@0.052632",
-      "statsd.test.dist:123.48216|d|@0.045455",
-      "statsd.test.dist:150.92264|d|@0.037037",
-      "statsd.test.dist:184.461004|d|@0.029412",
-      "statsd.test.dist:225.452339|d|@0.02439",
-      "statsd.test.dist:275.552858|d|@0.02",
-      "statsd.test.dist:336.786827|d|@0.016393",
-      "statsd.test.dist:411.628344|d|@0.013333",
-      "statsd.test.dist:503.101309|d|@0.01087",
-      "statsd.test.dist:614.9016|d|@0.009009",
-      "statsd.test.dist:751.5464|d|@0.007299",
-      "statsd.test.dist:918.556711|d|@0.005988",
-      "statsd.test.dist:1122.680424|d|@0.012195",
-      #
-      "statsd.test.dist:101.030858|d|@1.0|#foo:bar",
-      "statsd.test.dist:225.452339|d|@1.0|#foo:bar",
-      "statsd.test.dist:336.786827|d|@1.0|#foo:bar",
-      "statsd.test.dist:411.628344|d|@1.0|#foo:bar",
-      "statsd.test.dist:503.101309|d|@1.0|#foo:bar",
-      "statsd.test.dist:614.9016|d|@1.0|#foo:bar",
-      "statsd.test.dist:751.5464|d|@1.0|#foo:bar",
-      "statsd.test.dist:918.556711|d|@0.5|#foo:bar",
-      "statsd.test.dist:1122.680424|d|@1.0|#foo:bar"
-    ]
-
-    packets = get_statsd_packets(tid, %{formatter: :datadog})
-    assert parse_packets(packets) == parse_packets(expected)
-  end
-
-  test "metrics are batched according to mtu option" do
-    tid = Storage.new(StorageCounter.fresh_id())
-
-    for i <- 1..10 do
-      sum = Metrics.sum("statsd.test.sum.#{i}")
-      last_value = Metrics.last_value("statsd.test.gauge.#{i}")
-
-      for j <- 1..10 do
-        Storage.insert_metric(tid, sum, j, %{})
-        Storage.insert_metric(tid, last_value, j, %{})
-      end
-    end
-
-    expected_metrics =
-      [
-        "statsd.test.sum.5:55|c",
-        "statsd.test.sum.4:55|c",
-        "statsd.test.sum.3:55|c",
-        "statsd.test.sum.2:55|c",
-        "statsd.test.sum.10:55|c",
-        "statsd.test.sum.1:55|c",
-        "statsd.test.gauge.2:10|g",
-        "statsd.test.gauge.10:10|g",
-        "statsd.test.gauge.1:10|g",
-        "statsd.test.sum.9:55|c",
-        "statsd.test.sum.8:55|c",
-        "statsd.test.sum.7:55|c",
-        "statsd.test.sum.6:55|c",
-        "statsd.test.gauge.9:10|g",
-        "statsd.test.gauge.8:10|g",
-        "statsd.test.gauge.7:10|g",
-        "statsd.test.gauge.6:10|g",
-        "statsd.test.gauge.5:10|g",
-        "statsd.test.gauge.4:10|g",
-        "statsd.test.gauge.3:10|g"
+      opts = [
+        name: name,
+        metrics: [counter],
+        storage: unquote(impl)
       ]
-      |> parse_packets()
 
-    packets = get_statsd_packets(tid, %{mtu: 100})
+      {:ok, _pid} = Peep.start_link(opts)
 
-    assert parse_packets(packets) == expected_metrics
+      for i <- 1..10 do
+        Peep.insert_metric(name, counter, 1, %{})
 
-    for packet <- packets do
-      assert IO.iodata_length(packet) <= 100
+        if rem(i, 2) == 0 do
+          Peep.insert_metric(name, counter, 1, %{even: true})
+        end
+      end
+
+      expected = ["statsd.test.counter:10|c", "statsd.test.counter:5|c|#even:true"]
+      assert parse_packets(get_statsd_packets(name)) == parse_packets(expected)
     end
 
-    packets = get_statsd_packets(tid, %{mtu: 200})
+    test "#{impl} - a sum can be formatted" do
+      name = StorageCounter.fresh_id()
 
-    assert parse_packets(packets) == expected_metrics
+      sum = Metrics.sum("statsd.test.sum")
 
-    for packet <- packets do
-      assert IO.iodata_length(packet) <= 200
+      opts = [
+        name: name,
+        metrics: [sum],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      for i <- 1..10 do
+        Peep.insert_metric(name, sum, 1, %{})
+
+        if rem(i, 2) == 0 do
+          Peep.insert_metric(name, sum, 1, %{even: true})
+        end
+      end
+
+      expected = ["statsd.test.sum:10|c", "statsd.test.sum:5|c|#even:true"]
+      assert parse_packets(get_statsd_packets(name)) == parse_packets(expected)
+    end
+
+    test "#{impl} - a last_value can be formatted" do
+      name = StorageCounter.fresh_id()
+
+      last_value = Metrics.last_value("statsd.test.gauge")
+
+      opts = [
+        name: name,
+        metrics: [last_value],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      for i <- 1..10 do
+        Peep.insert_metric(name, last_value, i, %{})
+
+        if rem(i, 2) == 1 do
+          Peep.insert_metric(name, last_value, i, %{odd: true})
+        end
+      end
+
+      expected = ["statsd.test.gauge:10|g", "statsd.test.gauge:9|g|#odd:true"]
+      assert parse_packets(get_statsd_packets(name)) == parse_packets(expected)
+    end
+
+    test "#{impl} - a distribution can be formatted (standard)" do
+      name = StorageCounter.fresh_id()
+
+      dist = Metrics.distribution("statsd.test.dist", reporter_options: [max_value: 1000])
+
+      opts = [
+        name: name,
+        metrics: [dist],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      for i <- 1..1000 do
+        Peep.insert_metric(name, dist, i, %{})
+
+        if rem(i, 100) == 0 do
+          Peep.insert_metric(name, dist, i, %{foo: :bar})
+        end
+      end
+
+      expected = [
+        "statsd.test.dist:1.0|ms|@1.0",
+        "statsd.test.dist:2.23152|ms|@1.0",
+        "statsd.test.dist:3.333505|ms|@1.0",
+        "statsd.test.dist:4.074283|ms|@1.0",
+        "statsd.test.dist:6.086275|ms|@0.5",
+        "statsd.test.dist:7.438781|ms|@1.0",
+        "statsd.test.dist:9.091843|ms|@0.5",
+        "statsd.test.dist:11.112253|ms|@0.5",
+        "statsd.test.dist:13.581642|ms|@0.5",
+        "statsd.test.dist:16.599785|ms|@0.333333",
+        "statsd.test.dist:20.288626|ms|@0.25",
+        "statsd.test.dist:24.79721|ms|@0.25",
+        "statsd.test.dist:30.307701|ms|@0.166667",
+        "statsd.test.dist:37.042745|ms|@0.142857",
+        "statsd.test.dist:45.274466|ms|@0.125",
+        "statsd.test.dist:55.335459|ms|@0.1",
+        "statsd.test.dist:67.632227|ms|@0.083333",
+        "statsd.test.dist:82.661611|ms|@0.066667",
+        "statsd.test.dist:101.030858|ms|@0.052632",
+        "statsd.test.dist:123.48216|ms|@0.045455",
+        "statsd.test.dist:150.92264|ms|@0.037037",
+        "statsd.test.dist:184.461004|ms|@0.029412",
+        "statsd.test.dist:225.452339|ms|@0.02439",
+        "statsd.test.dist:275.552858|ms|@0.02",
+        "statsd.test.dist:336.786827|ms|@0.016393",
+        "statsd.test.dist:411.628344|ms|@0.013333",
+        "statsd.test.dist:503.101309|ms|@0.01087",
+        "statsd.test.dist:614.9016|ms|@0.009009",
+        "statsd.test.dist:751.5464|ms|@0.007299",
+        "statsd.test.dist:918.556711|ms|@0.005988",
+        "statsd.test.dist:1122.680424|ms|@0.012195",
+        #
+        "statsd.test.dist:101.030858|ms|@1.0|#foo:bar",
+        "statsd.test.dist:225.452339|ms|@1.0|#foo:bar",
+        "statsd.test.dist:336.786827|ms|@1.0|#foo:bar",
+        "statsd.test.dist:411.628344|ms|@1.0|#foo:bar",
+        "statsd.test.dist:503.101309|ms|@1.0|#foo:bar",
+        "statsd.test.dist:614.9016|ms|@1.0|#foo:bar",
+        "statsd.test.dist:751.5464|ms|@1.0|#foo:bar",
+        "statsd.test.dist:918.556711|ms|@0.5|#foo:bar",
+        "statsd.test.dist:1122.680424|ms|@1.0|#foo:bar"
+      ]
+
+      packets = get_statsd_packets(name, %{formatter: :standard})
+
+      assert parse_packets(packets) == parse_packets(expected)
+    end
+
+    test "#{impl} - a distribution can be formatted (datadog)" do
+      name = StorageCounter.fresh_id()
+
+      dist = Metrics.distribution("statsd.test.dist", reporter_options: [max_value: 1000])
+
+      opts = [
+        name: name,
+        metrics: [dist],
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      for i <- 1..1000 do
+        Peep.insert_metric(name, dist, i, %{})
+
+        if rem(i, 100) == 0 do
+          Peep.insert_metric(name, dist, i, %{foo: :bar})
+        end
+      end
+
+      expected = [
+        "statsd.test.dist:1.0|d|@1.0",
+        "statsd.test.dist:2.23152|d|@1.0",
+        "statsd.test.dist:3.333505|d|@1.0",
+        "statsd.test.dist:4.074283|d|@1.0",
+        "statsd.test.dist:6.086275|d|@0.5",
+        "statsd.test.dist:7.438781|d|@1.0",
+        "statsd.test.dist:9.091843|d|@0.5",
+        "statsd.test.dist:11.112253|d|@0.5",
+        "statsd.test.dist:13.581642|d|@0.5",
+        "statsd.test.dist:16.599785|d|@0.333333",
+        "statsd.test.dist:20.288626|d|@0.25",
+        "statsd.test.dist:24.79721|d|@0.25",
+        "statsd.test.dist:30.307701|d|@0.166667",
+        "statsd.test.dist:37.042745|d|@0.142857",
+        "statsd.test.dist:45.274466|d|@0.125",
+        "statsd.test.dist:55.335459|d|@0.1",
+        "statsd.test.dist:67.632227|d|@0.083333",
+        "statsd.test.dist:82.661611|d|@0.066667",
+        "statsd.test.dist:101.030858|d|@0.052632",
+        "statsd.test.dist:123.48216|d|@0.045455",
+        "statsd.test.dist:150.92264|d|@0.037037",
+        "statsd.test.dist:184.461004|d|@0.029412",
+        "statsd.test.dist:225.452339|d|@0.02439",
+        "statsd.test.dist:275.552858|d|@0.02",
+        "statsd.test.dist:336.786827|d|@0.016393",
+        "statsd.test.dist:411.628344|d|@0.013333",
+        "statsd.test.dist:503.101309|d|@0.01087",
+        "statsd.test.dist:614.9016|d|@0.009009",
+        "statsd.test.dist:751.5464|d|@0.007299",
+        "statsd.test.dist:918.556711|d|@0.005988",
+        "statsd.test.dist:1122.680424|d|@0.012195",
+        #
+        "statsd.test.dist:101.030858|d|@1.0|#foo:bar",
+        "statsd.test.dist:225.452339|d|@1.0|#foo:bar",
+        "statsd.test.dist:336.786827|d|@1.0|#foo:bar",
+        "statsd.test.dist:411.628344|d|@1.0|#foo:bar",
+        "statsd.test.dist:503.101309|d|@1.0|#foo:bar",
+        "statsd.test.dist:614.9016|d|@1.0|#foo:bar",
+        "statsd.test.dist:751.5464|d|@1.0|#foo:bar",
+        "statsd.test.dist:918.556711|d|@0.5|#foo:bar",
+        "statsd.test.dist:1122.680424|d|@1.0|#foo:bar"
+      ]
+
+      packets = get_statsd_packets(name, %{formatter: :datadog})
+      assert parse_packets(packets) == parse_packets(expected)
+    end
+
+    test "#{impl} - metrics are batched according to mtu option" do
+      name = StorageCounter.fresh_id()
+
+      sum = fn i -> Metrics.sum("statsd.test.sum.#{i}") end
+      last_value = fn i -> Metrics.last_value("statsd.test.gauge.#{i}") end
+
+      metrics =
+        Enum.reduce(1..10, [], fn i, acc ->
+          [sum.(i), last_value.(i) | acc]
+        end)
+
+      opts = [
+        name: name,
+        metrics: metrics,
+        storage: unquote(impl)
+      ]
+
+      {:ok, _pid} = Peep.start_link(opts)
+
+      for i <- 1..10 do
+        sum = sum.(i)
+        last_value = last_value.(i)
+
+        for j <- 1..10 do
+          Peep.insert_metric(name, sum, j, %{})
+          Peep.insert_metric(name, last_value, j, %{})
+        end
+      end
+
+      expected_metrics =
+        [
+          "statsd.test.sum.5:55|c",
+          "statsd.test.sum.4:55|c",
+          "statsd.test.sum.3:55|c",
+          "statsd.test.sum.2:55|c",
+          "statsd.test.sum.10:55|c",
+          "statsd.test.sum.1:55|c",
+          "statsd.test.gauge.2:10|g",
+          "statsd.test.gauge.10:10|g",
+          "statsd.test.gauge.1:10|g",
+          "statsd.test.sum.9:55|c",
+          "statsd.test.sum.8:55|c",
+          "statsd.test.sum.7:55|c",
+          "statsd.test.sum.6:55|c",
+          "statsd.test.gauge.9:10|g",
+          "statsd.test.gauge.8:10|g",
+          "statsd.test.gauge.7:10|g",
+          "statsd.test.gauge.6:10|g",
+          "statsd.test.gauge.5:10|g",
+          "statsd.test.gauge.4:10|g",
+          "statsd.test.gauge.3:10|g"
+        ]
+        |> parse_packets()
+
+      packets = get_statsd_packets(name, %{mtu: 100})
+
+      assert parse_packets(packets) == expected_metrics
+
+      for packet <- packets do
+        assert IO.iodata_length(packet) <= 100
+      end
+
+      packets = get_statsd_packets(name, %{mtu: 200})
+
+      assert parse_packets(packets) == expected_metrics
+
+      for packet <- packets do
+        assert IO.iodata_length(packet) <= 200
+      end
     end
   end
 
-  defp get_statsd_packets(tid, opts \\ %{}) do
+  defp get_statsd_packets(name, opts \\ %{}) do
     formatter = opts[:formatter] || :standard
     mtu = opts[:mtu] || 1_000_000
 
     state = Statsd.make_state(%{formatter: formatter, mtu: mtu})
 
     {_cache, packets} =
-      Storage.get_all_metrics(tid)
+      Peep.get_all_metrics(name)
       |> Statsd.prepare(state)
 
     for p <- packets do

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -209,5 +209,33 @@ defmodule Storage.Test do
 
       assert unquote(impl).get_metric(tid, dist, []) == expected
     end
+
+    test "#{impl} - storage_size/1" do
+      storage = unquote(impl).new()
+
+      counter = Metrics.counter("storage.test.counter")
+      sum = Metrics.sum("storage.test.sum")
+      last_value = Metrics.last_value("storage.test.gauge")
+
+      dist =
+        Metrics.distribution("storage.test.distribution", reporter_options: [max_value: 1000])
+
+      metrics = [counter, sum, last_value, dist]
+
+      tags_sets = [
+        %{},
+        %{foo: :bar},
+        %{baz: :quux}
+      ]
+
+      for metric <- metrics, tags <- tags_sets do
+        %{size: size_before, memory: mem_before} = unquote(impl).storage_size(storage)
+        unquote(impl).insert_metric(storage, metric, 5, tags)
+        %{size: size_after, memory: mem_after} = unquote(impl).storage_size(storage)
+
+        assert size_after > size_before
+        assert mem_after > mem_before
+      end
+    end
   end
 end

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -1,187 +1,213 @@
-defmodule StorageTest do
+defmodule Storage.Test do
   use ExUnit.Case
 
-  alias Peep.Storage
   alias Telemetry.Metrics
 
-  alias Peep.Support.StorageCounter
+  @impls [Peep.Storage, Peep.Storage.Striped]
 
-  test "a counter can be stored and retrieved" do
-    tid = Storage.new(StorageCounter.fresh_id())
+  for impl <- @impls do
+    test "#{impl} - a counter can be stored and retrieved" do
+      tids = unquote(impl).new()
 
-    counter = Metrics.counter("storage.test.counter")
+      counter = Metrics.counter("storage.test.counter")
 
-    for i <- 1..10 do
-      Storage.insert_metric(tid, counter, 1, %{})
+      f = fn ->
+        for i <- 1..10 do
+          unquote(impl).insert_metric(tids, counter, 1, %{})
 
-      if rem(i, 2) == 0 do
-        Storage.insert_metric(tid, counter, 1, %{even: true})
+          if rem(i, 2) == 0 do
+            unquote(impl).insert_metric(tids, counter, 1, %{even: true})
+          end
+        end
       end
+
+      1..100 |> Enum.map(fn _ -> Task.async(f) end) |> Task.await_many()
+
+      assert unquote(impl).get_metric(tids, counter, %{}) == 1000
+      assert unquote(impl).get_metric(tids, counter, %{even: true}) == 500
     end
 
-    assert Storage.get_metric(tid, counter, %{}) == 10
-    assert Storage.get_metric(tid, counter, %{even: true}) == 5
-  end
+    test "#{impl} - a sum can be stored and retrieved" do
+      tid = unquote(impl).new()
 
-  test "a sum can be stored and retrieved" do
-    tid = Storage.new(StorageCounter.fresh_id())
+      sum = Metrics.sum("storage.test.sum")
 
-    sum = Metrics.sum("storage.test.sum")
+      f = fn ->
+        for i <- 1..10 do
+          unquote(impl).insert_metric(tid, sum, 2, %{})
 
-    for i <- 1..10 do
-      Storage.insert_metric(tid, sum, 2, %{})
-
-      if rem(i, 2) == 0 do
-        Storage.insert_metric(tid, sum, 3, %{even: true})
+          if rem(i, 2) == 0 do
+            unquote(impl).insert_metric(tid, sum, 3, %{even: true})
+          end
+        end
       end
+
+      1..100 |> Enum.map(fn _ -> Task.async(f) end) |> Task.await_many()
+
+      assert unquote(impl).get_metric(tid, sum, []) == 100 * 20
+      assert unquote(impl).get_metric(tid, sum, even: true) == 100 * 15
     end
 
-    assert Storage.get_metric(tid, sum, []) == 20
-    assert Storage.get_metric(tid, sum, even: true) == 15
-  end
+    test "#{impl} - a last_value can be stored and retrieved" do
+      tid = unquote(impl).new()
 
-  test "a last_value can be stored and retrieved" do
-    tid = Storage.new(StorageCounter.fresh_id())
+      last_value = Metrics.last_value("storage.test.gauge")
 
-    last_value = Metrics.last_value("storage.test.gauge")
+      f = fn ->
+        for i <- 1..10 do
+          unquote(impl).insert_metric(tid, last_value, i, %{})
 
-    for i <- 1..10 do
-      Storage.insert_metric(tid, last_value, i, %{})
-
-      if rem(i, 2) == 1 do
-        Storage.insert_metric(tid, last_value, i, %{odd: true})
+          if rem(i, 2) == 1 do
+            unquote(impl).insert_metric(tid, last_value, i, %{odd: true})
+          end
+        end
       end
+
+      1..100 |> Enum.map(fn _ -> Task.async(f) end) |> Task.await_many()
+
+      assert unquote(impl).get_metric(tid, last_value, []) == 10
+      assert unquote(impl).get_metric(tid, last_value, odd: true) == 9
     end
 
-    assert Storage.get_metric(tid, last_value, []) == 10
-    assert Storage.get_metric(tid, last_value, odd: true) == 9
-  end
+    test "#{impl} - a distribution can be stored and retrieved" do
+      tid = unquote(impl).new()
 
-  test "a distribution can be stored and retrieved" do
-    tid = Storage.new(StorageCounter.fresh_id())
+      dist =
+        Metrics.distribution("storage.test.distribution", reporter_options: [max_value: 1000])
 
-    dist = Metrics.distribution("storage.test.distribution", reporter_options: [max_value: 1000])
+      f = fn ->
+        for i <- 0..2000 do
+          unquote(impl).insert_metric(tid, dist, i, %{})
+        end
+      end
 
-    for i <- 0..2000 do
-      Storage.insert_metric(tid, dist, i, %{})
+      1..100 |> Enum.map(fn _ -> Task.async(f) end) |> Task.await_many()
+
+      expected = %{
+        "1.0" => 100 * 2,
+        "1.222222" => 0,
+        "1.493827" => 0,
+        "1.825789" => 0,
+        "2.727413" => 0,
+        "2.23152" => 100,
+        "3.333505" => 100,
+        "4.074283" => 100,
+        "4.97968" => 0,
+        "6.086275" => 100 * 2,
+        "7.438781" => 100,
+        "9.091843" => 100 * 2,
+        "11.112253" => 100 * 2,
+        "13.581642" => 100 * 2,
+        "16.599785" => 100 * 3,
+        "20.288626" => 100 * 4,
+        "24.79721" => 100 * 4,
+        "30.307701" => 100 * 6,
+        "37.042745" => 100 * 7,
+        "45.274466" => 100 * 8,
+        "55.335459" => 100 * 10,
+        "67.632227" => 100 * 12,
+        "82.661611" => 100 * 15,
+        "101.030858" => 100 * 19,
+        "123.48216" => 100 * 22,
+        "150.92264" => 100 * 27,
+        "184.461004" => 100 * 34,
+        "225.452339" => 100 * 41,
+        "275.552858" => 100 * 50,
+        "336.786827" => 100 * 61,
+        "411.628344" => 100 * 75,
+        "503.101309" => 100 * 92,
+        "614.9016" => 100 * 111,
+        "751.5464" => 100 * 137,
+        "918.556711" => 100 * 167,
+        "1122.680424" => 100 * 204,
+        :infinity => 100 * 878,
+        :sum => 100 * 2_001_000
+      }
+
+      assert unquote(impl).get_metric(tid, dist, []) == expected
     end
 
-    expected = %{
-      "1.0" => 2,
-      "1.222222" => 0,
-      "1.493827" => 0,
-      "1.825789" => 0,
-      "2.727413" => 0,
-      "2.23152" => 1,
-      "3.333505" => 1,
-      "4.074283" => 1,
-      "4.97968" => 0,
-      "6.086275" => 2,
-      "7.438781" => 1,
-      "9.091843" => 2,
-      "11.112253" => 2,
-      "13.581642" => 2,
-      "16.599785" => 3,
-      "20.288626" => 4,
-      "24.79721" => 4,
-      "30.307701" => 6,
-      "37.042745" => 7,
-      "45.274466" => 8,
-      "55.335459" => 10,
-      "67.632227" => 12,
-      "82.661611" => 15,
-      "101.030858" => 19,
-      "123.48216" => 22,
-      "150.92264" => 27,
-      "184.461004" => 34,
-      "225.452339" => 41,
-      "275.552858" => 50,
-      "336.786827" => 61,
-      "411.628344" => 75,
-      "503.101309" => 92,
-      "614.9016" => 111,
-      "751.5464" => 137,
-      "918.556711" => 167,
-      "1122.680424" => 204,
-      :infinity => 878,
-      :sum => 2_001_000
-    }
+    test "#{impl} - distribution bucket variability" do
+      tid = unquote(impl).new()
 
-    assert Storage.get_metric(tid, dist, []) == expected
-  end
+      dist =
+        Metrics.distribution("storage.test.distribution",
+          reporter_options: [
+            max_value: 1000,
+            bucket_variability: 0.25
+          ]
+        )
 
-  test "distribution bucket variability" do
-    tid = Storage.new(StorageCounter.fresh_id())
+      f = fn ->
+        for i <- 0..1000 do
+          unquote(impl).insert_metric(tid, dist, i, %{})
+        end
+      end
 
-    dist =
-      Metrics.distribution("storage.test.distribution",
-        reporter_options: [
-          max_value: 1000,
-          bucket_variability: 0.25
-        ]
-      )
+      1..100 |> Enum.map(fn _ -> Task.async(f) end) |> Task.await_many()
 
-    for i <- 0..1000 do
-      Storage.insert_metric(tid, dist, i, %{})
+      expected = %{
+        "1.0" => 2 * 100,
+        "1.666667" => 0,
+        "2.777778" => 100,
+        "4.62963" => 2 * 100,
+        "7.716049" => 3 * 100,
+        "12.860082" => 5 * 100,
+        "21.433471" => 9 * 100,
+        "35.722451" => 14 * 100,
+        "59.537418" => 24 * 100,
+        "99.22903" => 40 * 100,
+        "165.381717" => 66 * 100,
+        "275.636195" => 110 * 100,
+        "459.393658" => 184 * 100,
+        "765.656097" => 306 * 100,
+        "1276.093494" => 235 * 100,
+        :infinity => 0,
+        :sum => 500_500 * 100
+      }
+
+      assert unquote(impl).get_metric(tid, dist, []) == expected
     end
 
-    expected = %{
-      "1.0" => 2,
-      "1.666667" => 0,
-      "2.777778" => 1,
-      "4.62963" => 2,
-      "7.716049" => 3,
-      "12.860082" => 5,
-      "21.433471" => 9,
-      "35.722451" => 14,
-      "59.537418" => 24,
-      "99.22903" => 40,
-      "165.381717" => 66,
-      "275.636195" => 110,
-      "459.393658" => 184,
-      "765.656097" => 306,
-      "1276.093494" => 235,
-      :infinity => 0,
-      :sum => 500_500
-    }
+    test "#{impl} - default distribution handles negative values" do
+      tid = unquote(impl).new()
 
-    assert Storage.get_metric(tid, dist, []) == expected
-  end
+      dist =
+        Metrics.distribution("storage.test.distribution",
+          reporter_options: [
+            max_value: 500,
+            bucket_variability: 0.25
+          ]
+        )
 
-  test "default distribution handles negative values" do
-    tid = Storage.new(StorageCounter.fresh_id())
+      f = fn ->
+        for i <- -500..500 do
+          unquote(impl).insert_metric(tid, dist, i, %{})
+        end
+      end
 
-    dist =
-      Metrics.distribution("storage.test.distribution",
-        reporter_options: [
-          max_value: 500,
-          bucket_variability: 0.25
-        ]
-      )
+      1..100 |> Enum.map(fn _ -> Task.async(f) end) |> Task.await_many()
 
-    for i <- -500..500 do
-      Storage.insert_metric(tid, dist, i, %{})
+      expected = %{
+        "1.0" => 502 * 100,
+        "1.666667" => 0,
+        "2.777778" => 100,
+        "4.62963" => 2 * 100,
+        "7.716049" => 3 * 100,
+        "12.860082" => 5 * 100,
+        "21.433471" => 9 * 100,
+        "35.722451" => 14 * 100,
+        "59.537418" => 24 * 100,
+        "99.22903" => 40 * 100,
+        "165.381717" => 66 * 100,
+        "275.636195" => 110 * 100,
+        "459.393658" => 184 * 100,
+        "765.656097" => 41 * 100,
+        :infinity => 0,
+        :sum => 0
+      }
+
+      assert unquote(impl).get_metric(tid, dist, []) == expected
     end
-
-    expected = %{
-      "1.0" => 502,
-      "1.666667" => 0,
-      "2.777778" => 1,
-      "4.62963" => 2,
-      "7.716049" => 3,
-      "12.860082" => 5,
-      "21.433471" => 9,
-      "35.722451" => 14,
-      "59.537418" => 24,
-      "99.22903" => 40,
-      "165.381717" => 66,
-      "275.636195" => 110,
-      "459.393658" => 184,
-      "765.656097" => 41,
-      :infinity => 0,
-      :sum => 0
-    }
-
-    assert Storage.get_metric(tid, dist, []) == expected
   end
 end

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -3,7 +3,7 @@ defmodule Storage.Test do
 
   alias Telemetry.Metrics
 
-  @impls [Peep.Storage, Peep.Storage.Striped]
+  @impls [Peep.Storage.ETS, Peep.Storage.Striped]
 
   for impl <- @impls do
     test "#{impl} - a counter can be stored and retrieved" do


### PR DESCRIPTION
closes #16
closes #4

Unfortunately the diff is a bit inflated due to indenting a bunch of lines in test modules. Sorry about that.

This PR allows for users to configure how metrics are stored with in Peep. When a user starts Peep with `storage: :default`, the pre-existing metrics storage is used. When a user starts Peep with `storage: :striped`, Peep starts with a new storage facility, which uses one ETS table per scheduler thread. The choice of storage engine for a Peep process is stored in `:persistent_term`, as it will need to be retrieved by any process that calls `:telemetry.execute/3`.

Peep.Storage.Striped trades increased memory usage and slower reading of metrics for less lock contention while inserting metrics, which may improve performance if you're using Peep to track many metrics on powerful hardware.

Most of the tests have been refactored to use both storage implementations.

This PR also introduces `Peep.storage_size/1` which can be called periodically using a library like `:telemetry_poller`. When Peep is running, it returns a map of measurements that can be passed directly to `:telemetry.execute/3`.