### PR TITLE
Fixing formatting issue with `:infinity`

### DIFF
--- a/lib/peep/prometheus.ex
+++ b/lib/peep/prometheus.ex
@@ -116,6 +116,7 @@ defmodule Peep.Prometheus do
   defp format_value(true), do: "1"
   defp format_value(false), do: "0"
   defp format_value(nil), do: "0"
+  defp format_value(:infinity), do: "+Inf"
   defp format_value(n) when is_integer(n), do: :erlang.integer_to_binary(n)
   defp format_value(f) when is_float(f), do: :erlang.float_to_binary(f, [:compact])
 


### PR DESCRIPTION
Came across this error today in an app running PromEx:

```
[error] Task #PID<0.4021.0> started from Whoosh.PromEx.ETSCronFlusher terminating
** (FunctionClauseError) no function clause matching in Peep.Prometheus.format_value/1
    (peep 3.2.0) lib/peep/prometheus.ex:116: Peep.Prometheus.format_value(:infinity)
    (peep 3.2.0) lib/peep/prometheus.ex:93: anonymous fn/2 in Peep.Prometheus.format_standard/2
    ...
```

And while I am not 100% sure as to how Peep works internally or how `:infinity` ended up in that value, according to the [Prometheus spec](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-format-details) `+Inf`, `-Inf`, and `NaN` are all valid values for a metric. This PR just adds support for formatting `:infinity` -> `+Inf` values to solve my immediate issue...but not sure what to do about the other two.