### PR TITLE
Use Integer/Float.to_string functions

### DIFF
--- a/lib/peep/prometheus.ex
+++ b/lib/peep/prometheus.ex
@@ -116,8 +116,8 @@ defmodule Peep.Prometheus do
   defp format_value(true), do: "1"
   defp format_value(false), do: "0"
   defp format_value(nil), do: "0"
-  defp format_value(n) when is_integer(n), do: :erlang.integer_to_binary(n)
-  defp format_value(f) when is_float(f), do: :erlang.float_to_binary(f, [:compact])
+  defp format_value(n) when is_integer(n), do: Integer.to_string(n)
+  defp format_value(f) when is_float(f), do:  Float.to_string(f)
 
   defp escape(nil), do: "nil"
 


### PR DESCRIPTION
Float.to_string defaults to [:short], which is the most efficient version.

Both are inlined by the compiler, so we can keep it as idiomatic Elixir.