### PR TITLE
Optimize prometheus export

### DIFF
--- a/test/prometheus_test.exs
+++ b/test/prometheus_test.exs
@@ -374,8 +374,7 @@ defmodule PrometheusTest do
 
   defp lines_to_string(lines) do
     lines
-    |> Enum.intersperse(?\n)
-    |> then(&[&1, ?\n])
+    |> Enum.map(&[&1, ?\n])
     |> IO.iodata_to_binary()
   end
 end


### PR DESCRIPTION
* Avoid traversing lists multiple times
* Rely on IO data more frequently and share parts
* Do a single pass escape instead of multiple
* Use Float.to_string/1 (as it uses Ryu for 3x faster conversion)