### PR TITLE
Drop non-numeric metric values

### DIFF
--- a/lib/peep/event_handler.ex
+++ b/lib/peep/event_handler.ex
@@ -47,14 +47,18 @@ defmodule Peep.EventHandler do
         keep: keep
       } = metric
 
-      if value = keep?(keep, metadata) && fetch_measurement(measurement, measurements, metadata) do
-        tag_values =
-          global_tags
-          |> Map.merge(tag_values.(metadata))
+      case keep?(keep, metadata) && fetch_measurement(measurement, measurements, metadata) do
+        value when is_number(value) ->
+          tag_values =
+            global_tags
+            |> Map.merge(tag_values.(metadata))
 
-        tags = Map.new(tags, &{&1, Map.get(tag_values, &1, "")})
+          tags = Map.new(tags, &{&1, Map.get(tag_values, &1, "")})
 
-        Peep.insert_metric(name, metric, value, tags)
+          Peep.insert_metric(name, metric, value, tags)
+
+        _ ->
+          nil
       end
     end
   end

--- a/lib/peep/storage/ets.ex
+++ b/lib/peep/storage/ets.ex
@@ -40,9 +40,14 @@ defmodule Peep.Storage.ETS do
     :ets.update_counter(tid, key, {2, value}, {key, 0})
   end
 
-  def insert_metric(tid, %Metrics.LastValue{} = metric, value, %{} = tags) do
+  def insert_metric(tid, %Metrics.LastValue{} = metric, value, %{} = tags)
+      when is_number(value) do
     key = {metric, tags}
     :ets.insert(tid, {key, value})
+  end
+
+  def insert_metric(_tid, %Metrics.LastValue{} = _metric, _value, _tags) do
+    raise ArgumentError
   end
 
   def insert_metric(tid, %Metrics.Distribution{} = metric, value, %{} = tags) do

--- a/lib/peep/storage/striped.ex
+++ b/lib/peep/storage/striped.ex
@@ -47,11 +47,16 @@ defmodule Peep.Storage.Striped do
     :ets.update_counter(tid, key, {2, value}, {key, 0})
   end
 
-  def insert_metric(tids, %Metrics.LastValue{} = metric, value, %{} = tags) do
+  def insert_metric(tids, %Metrics.LastValue{} = metric, value, %{} = tags)
+      when is_number(value) do
     tid = get_tid(tids)
     now = System.monotonic_time()
     key = {metric, tags}
     :ets.insert(tid, {key, {now, value}})
+  end
+
+  def insert_metric(_tid, %Metrics.LastValue{} = _metric, _value, _tags) do
+    raise ArgumentError
   end
 
   def insert_metric(tids, %Metrics.Distribution{} = metric, value, %{} = tags) do

--- a/test/peep_test.exs
+++ b/test/peep_test.exs
@@ -140,4 +140,40 @@ defmodule PeepTest do
 
     assert [] == :telemetry.list_handlers(prefix)
   end
+
+  test "Non-numeric values are dropped" do
+    name = :"#{__MODULE__}_non_numeric_values"
+
+    sum = Metrics.sum("#{name}.sum", event_name: [name, :sum], measurement: :value)
+
+    last_value =
+      Metrics.last_value("#{name}.last_value",
+        event_name: [name, :last_value],
+        measurement: :value
+      )
+
+    dist =
+      Metrics.distribution(
+        "#{name}.dist",
+        event_name: [name, :dist],
+        measurement: :value
+      )
+
+    metrics = [sum, last_value, dist]
+
+    options = [
+      name: name,
+      metrics: metrics
+    ]
+
+    {:ok, _pid} = Peep.start_link(options)
+
+    :telemetry.execute([name, :sum], %{value: :foo})
+    :telemetry.execute([name, :last_value], %{value: "bar"})
+    :telemetry.execute([name, :dist], %{value: []})
+
+    assert Peep.get_metric(name, sum, []) == 0
+    assert Peep.get_metric(name, last_value, []) == nil
+    assert Peep.get_metric(name, dist, []) == nil
+  end
 end

--- a/test/prometheus_test.exs
+++ b/test/prometheus_test.exs
@@ -332,39 +332,6 @@ defmodule PrometheusTest do
       assert export(name) == lines_to_string(expected)
     end
 
-    test "#{impl} - non-number values" do
-      name = StorageCounter.fresh_id()
-
-      last_value =
-        Metrics.last_value(
-          "prometheus.test.gauge",
-          description: "a last_value",
-          tags: [:from]
-        )
-
-      opts = [
-        name: name,
-        metrics: [last_value],
-        storage: unquote(impl)
-      ]
-
-      {:ok, _pid} = Peep.start_link(opts)
-
-      Peep.insert_metric(name, last_value, true, %{from: true})
-      Peep.insert_metric(name, last_value, false, %{from: false})
-      Peep.insert_metric(name, last_value, nil, %{from: nil})
-
-      expected = [
-        "# HELP prometheus_test_gauge a last_value",
-        "# TYPE prometheus_test_gauge gauge",
-        ~s(prometheus_test_gauge{from="false"} 0),
-        ~s(prometheus_test_gauge{from="nil"} 0),
-        ~s(prometheus_test_gauge{from="true"} 1)
-      ]
-
-      assert export(name) == lines_to_string(expected)
-    end
-
     test "#{impl} - regression: label escaping" do
       name = StorageCounter.fresh_id()
 

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -237,5 +237,21 @@ defmodule Storage.Test do
         assert mem_after > mem_before
       end
     end
+
+    test "#{impl} - inserting a non-numeric value raises an exception" do
+      storage = unquote(impl).new()
+
+      sum = Metrics.sum("storage.test.sum")
+      last_value = Metrics.last_value("storage.test.gauge")
+
+      dist =
+        Metrics.distribution("storage.test.distribution", reporter_options: [max_value: 1000])
+
+      for metric <- [sum, last_value, dist] do
+        assert_raise ArgumentError, fn ->
+          unquote(impl).insert_metric(storage, metric, :foo, %{})
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
With this change, Peep.EventHandler will not call Peep.insert_metric/4 with a non-numeric value.

This change also unifies the behavior of Peep.Storage.{Striped, ETS}.insert_metric/4 such that, for all metric types, inserting a non-numeric metric value raises an ArgumentError. Previously, storing a non-numeric value in a Metrics.LastValue was allowed, while storing a non-numeric value for other metrics (except Metrics.Counter) all coincidentally raised ArgumentError.

It may seem redundant to make both of these changes, since avoiding all calls to Peep.insert_metric/4 should transitively prevent Peep.Storage.*.insert_metric/4 from being called with a bad argument. I can't argue that, but I like the behavior of raising an exception in Peep.Storage.*.insert_metric/4, since that should produce a 'loud' error when running Peep's tests. However, this does come with the slight drawback of calling Kernel.is_number/1 twice when storing a value associated with a Metrics.LastValue.