### PR TITLE
fix: add handling for escaped quotes in Peep.Prometheus.escape_help/2

### DIFF
--- a/lib/peep/prometheus.ex
+++ b/lib/peep/prometheus.ex
@@ -147,6 +147,7 @@ defmodule Peep.Prometheus do
     |> escape_help(<<>>)
   end
 
+  defp escape_help(<<?\", rest::binary>>, acc), do: escape_help(rest, <<acc::binary, ?\\, ?\">>)
   defp escape_help(<<?\\, rest::binary>>, acc), do: escape_help(rest, <<acc::binary, ?\\, ?\\>>)
   defp escape_help(<<?\n, rest::binary>>, acc), do: escape_help(rest, <<acc::binary, ?\\, ?\n>>)
   defp escape_help(<<h, rest::binary>>, acc), do: escape_help(rest, <<acc::binary, h>>)


### PR DESCRIPTION
Hey!

I ran into an issue with incorrect escaping of double quotes.  

```elixir
iex(node1@127.0.0.1)1> Peep.Prometheus.escape("\"postgres\"")
"\\\"postgres\""
```
at first glance, it looks like `escape_help/2` was missing handling for a single `\`

after the fix:
```elixir
iex(node1@127.0.0.1)1> Peep.Prometheus.escape("\"postgres\"")
"\\\"postgres\\\""
```

not too familiar with your codebase, so let me know if this makes sense!