### PR TITLE
Add Peep.prune_tags/2

### DIFF
--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -145,6 +145,25 @@ defmodule Peep do
     end
   end
 
+  @doc """
+  Removes metrics whose metadata contains the specified tag patterns.
+
+  Example inputs:
+
+  - `[%{foo: :bar}, %{baz: :quux}]` removes metrics with `foo == :bar` OR `baz == :quux`
+  - `[%{foo: :bar, baz: :quux}]` removes metrics with `foo == :bar` AND `baz == :quux`
+  - `[%{foo: :one}, %{foo: :two}]` removes metrics with `foo == :one` OR `foo == :two`
+  """
+  def prune_tags(name, tags_patterns) do
+    case Peep.Persistent.storage(name) do
+      {storage_mod, storage} ->
+        storage_mod.prune_tags(storage, tags_patterns)
+
+      _ ->
+        nil
+    end
+  end
+
   @impl true
   def init(options) do
     Process.flag(:trap_exit, true)

--- a/lib/peep/storage.ex
+++ b/lib/peep/storage.ex
@@ -6,4 +6,11 @@ defmodule Peep.Storage do
   @callback insert_metric(term(), Metrics.t(), term(), map()) :: any()
   @callback get_all_metrics(term()) :: map()
   @callback get_metric(term(), Metrics.t(), map()) :: any()
+
+  @doc """
+  Removes metrics whose metadata contains a specific tag key and value.
+  This is intended to improve situations where Peep emits metrics whose tags
+  have high cardinality.
+  """
+  @callback prune_tags(Enumerable.t(%{Metrics.tag() => term()}), map()) :: :ok
 end

--- a/lib/peep/storage.ex
+++ b/lib/peep/storage.ex
@@ -1,10 +1,34 @@
 defmodule Peep.Storage do
+  @moduledoc """
+  Behaviour for Peep storage backends. These functions are mainly called by Peep
+  during normal functioning. Ordinary usage of Peep should not require calling
+  any of these functions.
+  """
   alias Telemetry.Metrics
 
+  @doc """
+  Creates a new term representing a Peep storage backend.
+  """
   @callback new() :: term()
+
+  @doc """
+  Calculates the amount of memory used by a Peep storage backend.
+  """
   @callback storage_size(term()) :: %{size: non_neg_integer(), memory: non_neg_integer()}
+
+  @doc """
+  Stores a sample metric
+  """
   @callback insert_metric(term(), Metrics.t(), term(), map()) :: any()
+
+  @doc """
+  Retrieves all stored metrics
+  """
   @callback get_all_metrics(term()) :: map()
+
+  @doc """
+  Retrieves a single stored metric
+  """
   @callback get_metric(term(), Metrics.t(), map()) :: any()
 
   @doc """

--- a/lib/peep/storage/ets.ex
+++ b/lib/peep/storage/ets.ex
@@ -1,5 +1,12 @@
 defmodule Peep.Storage.ETS do
-  @moduledoc false
+  @moduledoc """
+  Peep.Storage implementation using a single ETS table.
+
+  A sane default for storing Peep metrics, with some simple optimizations.
+  If you discover that lock contention on Peep's ETS table is high,
+  consider switching to `Peep.Storage.Striped`, which reduces lock contention
+  at the cost of higher memory usage.
+  """
   alias Peep.Storage
   alias Telemetry.Metrics
 

--- a/lib/peep/storage/ets.ex
+++ b/lib/peep/storage/ets.ex
@@ -107,6 +107,32 @@ defmodule Peep.Storage.ETS do
     end
   end
 
+  @impl true
+  def prune_tags(tid, patterns) do
+    match_spec =
+      patterns
+      |> Enum.flat_map(fn pattern ->
+        counter_or_sum_key = {:_, pattern, :_}
+        dist_or_last_value_key = {:_, pattern}
+
+        [
+          {
+            {counter_or_sum_key, :_},
+            [],
+            [true]
+          },
+          {
+            {dist_or_last_value_key, :_},
+            [],
+            [true]
+          }
+        ]
+      end)
+
+    :ets.select_delete(tid, match_spec)
+    :ok
+  end
+
   defp group_metrics([], acc) do
     acc
   end

--- a/lib/peep/storage/striped.ex
+++ b/lib/peep/storage/striped.ex
@@ -1,11 +1,16 @@
 defmodule Peep.Storage.Striped do
-  @moduledoc false
+  @moduledoc """
+  Peep.Storage implementation using an ETS table per BEAM scheduler thread.
+
+  Offers less lock contention than `Peep.Storage.ETS`, at the cost of higher
+  memory usage. Recommended when executing thousands of metrics per second.
+  """
   alias Telemetry.Metrics
   alias Peep.Storage
 
   @behaviour Peep.Storage
 
-  @type tids() :: %{pos_integer() => :ets.tid()}
+  @typep tids() :: %{pos_integer() => :ets.tid()}
 
   @compile :inline
 

--- a/lib/peep/storage/striped.ex
+++ b/lib/peep/storage/striped.ex
@@ -163,6 +163,27 @@ defmodule Peep.Storage.Striped do
   end
 
   @impl true
+  def prune_tags(tids, patterns) do
+    match_spec =
+      patterns
+      |> Enum.map(fn pattern ->
+        metric_key = {:_, pattern}
+
+        {
+          {metric_key, :_},
+          [],
+          [true]
+        }
+      end)
+
+    for {_, tid} <- tids do
+      :ets.select_delete(tid, match_spec)
+    end
+
+    :ok
+  end
+
+  @impl true
   def get_all_metrics(tids) do
     acc = get_all_metrics(Map.values(tids), %{})
     remove_timestamps_from_last_values(acc)

--- a/mix.exs
+++ b/mix.exs
@@ -61,6 +61,7 @@ defmodule Peep.MixProject do
       source_ref: "v#{@version}",
       extras: [],
       groups_for_modules: [
+        Storage: [~r/Peep.Storage/],
         Bucketing: [~r/Peep.Buckets/]
       ]
     ]


### PR DESCRIPTION
closes #31.

This implements a basic method to remove unused tags from Peep.

@hauleth, I'd love to know what you think of this as a potential solution for removing per-tenant metrics in Supavisor. I juggled through a few different approaches, but ultimately I think this approach gives the most flexibility for the least amount of surprise while minimizing ETS table traversals.