### PR TITLE
fix: always include global tags

### DIFF
--- a/lib/peep/event_handler.ex
+++ b/lib/peep/event_handler.ex
@@ -52,7 +52,8 @@ defmodule Peep.EventHandler do
           global_tags
           |> Map.merge(tag_values.(metadata))
 
-        tags = Map.new(tags, &{&1, Map.get(tag_values, &1, "")})
+        tag_keys = tags ++ Map.keys(global_tags)
+        tags = Map.new(tag_keys, &{&1, Map.get(tag_values, &1, "")})
 
         Peep.insert_metric(name, metric, value, tags)
       end

--- a/test/peep_test.exs
+++ b/test/peep_test.exs
@@ -41,7 +41,7 @@ defmodule PeepTest do
   test "a worker with non-empty global_tags applies to all metrics" do
     name = :"#{__MODULE__}_global_tags"
 
-    tags = %{foo: "bar", baz: "quux"}
+    tags = %{foo: "bar", baz: "quux", service: "my-app", env: "production"}
     tag_keys = [:foo, :baz]
 
     counter = Metrics.counter("peep.counter", event_name: [:counter], tags: tag_keys)


### PR DESCRIPTION
Hey there, I would like to understand what was your intent here. Recently, I added some global tags,

```elixir
global_tags: %{
  env: System.fetch_env!("RELEASE_ENVIRONMENT"),
  service: "myapp"
}
```

Then I realized that they weren't included, so I wrote the test to prove the situation.

Ideally, I should not have to register the global tags under the `tag_keys` otherwise it is a lot of grunt work and error-prune.

It would feel odd to add such tags without the intention of including on everything.

The docs says "Additional tags published with every metric."