### PR TITLE
make badges into links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Peep
 
-![Hex version badge](https://img.shields.io/hexpm/v/peep)
-![Hexdocs badge](https://img.shields.io/static/v1?message=hexdocs&label=&color=B1A5EE)
+[![Hex version badge](https://img.shields.io/hexpm/v/peep)](https://hex.pm/packages/peep)
+[![Hexdocs badge](https://img.shields.io/static/v1?message=hexdocs&label=&color=B1A5EE)](https://hexdocs.pm/peep)
 ![Elixir CI badge](https://github.com/rkallos/peep/actions/workflows/elixir.yml/badge.svg)
 ![Hex licence badge](https://img.shields.io/hexpm/l/peep)
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Hex version badge](https://img.shields.io/hexpm/v/peep)](https://hex.pm/packages/peep)
 [![Hexdocs badge](https://img.shields.io/static/v1?message=hexdocs&label=&color=B1A5EE)](https://hexdocs.pm/peep)
-![Elixir CI badge](https://github.com/rkallos/peep/actions/workflows/elixir.yml/badge.svg)
-![Hex licence badge](https://img.shields.io/hexpm/l/peep)
+[![Elixir CI badge](https://github.com/rkallos/peep/actions/workflows/elixir.yml/badge.svg)](https://github.com/rkallos/peep/actions/workflows/elixir.yml)
+[![Hex licence badge](https://img.shields.io/hexpm/l/peep)](./LICENSE)
 
 `Telemetry.Metrics` reporter for Prometheus and StatsD (including Datadog).
 


### PR DESCRIPTION
👋 

Right now clicking on badges leads to images.
After this change they would link to Hex and Hexdocs.