### PR TITLE
Add Peep.Codegen

### DIFF
--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -80,6 +80,8 @@ defmodule Peep do
               statsd_state: nil
   end
 
+  @type metric_id() :: pos_integer()
+
   def child_spec(options) do
     %{id: peep_name!(options), start: {__MODULE__, :start_link, [options]}}
   end
@@ -95,9 +97,12 @@ defmodule Peep do
   end
 
   def insert_metric(name, metric, value, tags) do
-    case Peep.Persistent.storage(name) do
-      {storage_mod, storage} ->
-        storage_mod.insert_metric(storage, metric, value, tags)
+    case Peep.Persistent.fetch(name) do
+      %Peep.Persistent{
+        storage: {storage_mod, storage},
+        metrics_to_ids: %{^metric => id}
+      } ->
+        storage_mod.insert_metric(storage, id, metric, value, tags)
 
       _ ->
         nil
@@ -123,9 +128,9 @@ defmodule Peep do
   StatsD data.
   """
   def get_all_metrics(name) do
-    case Peep.Persistent.storage(name) do
-      {storage_mod, storage} ->
-        storage_mod.get_all_metrics(storage)
+    case Peep.Persistent.fetch(name) do
+      %Peep.Persistent{storage: {storage_mod, storage}} = p ->
+        storage_mod.get_all_metrics(storage, p)
 
       _ ->
         nil
@@ -135,10 +140,17 @@ defmodule Peep do
   @doc """
   Fetches a single metric from storage. Currently only used in tests.
   """
+  def get_metric(name, metric, tags) when is_list(tags) do
+    get_metric(name, metric, Map.new(tags))
+  end
+
   def get_metric(name, metric, tags) do
-    case Peep.Persistent.storage(name) do
-      {storage_mod, storage} ->
-        storage_mod.get_metric(storage, metric, tags)
+    case Peep.Persistent.fetch(name) do
+      %Peep.Persistent{
+        storage: {storage_mod, storage},
+        metrics_to_ids: %{^metric => id}
+      } ->
+        storage_mod.get_metric(storage, id, metric, tags)
 
       _ ->
         nil
@@ -164,12 +176,85 @@ defmodule Peep do
     end
   end
 
+  def allow_metric?(%Telemetry.Metrics.Summary{} = metric) do
+    Logger.warning("The summary metric type is unsupported. Dropping #{inspect(metric.name)}")
+    false
+  end
+
+  def allow_metric?(%Telemetry.Metrics.Distribution{reporter_options: opts} = metric) do
+    key = :max_value
+
+    case Keyword.get(opts, key) do
+      nil ->
+        true
+
+      n when is_number(n) ->
+        true
+
+      _ ->
+        Logger.warning(
+          "Distributions must have a numeric value assigned to #{inspect(key)} in reporter_options. Dropping #{inspect(metric.name)}"
+        )
+
+        false
+    end
+  end
+
+  def allow_metric?(_) do
+    true
+  end
+
+  def assign_metric_ids(metrics) do
+    filtered_metrics = Enum.filter(metrics, &allow_metric?/1)
+
+    assign_metric_ids(
+      Enum.reverse(filtered_metrics),
+      %{},
+      %{},
+      %{},
+      length(filtered_metrics)
+    )
+  end
+
+  defp assign_metric_ids([], events_to_metrics, ids_to_metrics, metrics_to_ids, _counter) do
+    %{
+      events_to_metrics: events_to_metrics,
+      ids_to_metrics: ids_to_metrics,
+      metrics_to_ids: metrics_to_ids
+    }
+  end
+
+  defp assign_metric_ids([metric | rest], etm, itm, mti, counter) do
+    %{event_name: event_name} = metric
+
+    etm =
+      case etm do
+        %{^event_name => metrics} ->
+          %{etm | event_name => [{metric, counter} | metrics]}
+
+        _ ->
+          Map.put(etm, event_name, [{metric, counter}])
+      end
+
+    itm = Map.put(itm, counter, metric)
+    mti = Map.put(mti, metric, counter)
+
+    assign_metric_ids(rest, etm, itm, mti, counter - 1)
+  end
+
+  # callbacks
+
   @impl true
   def init(options) do
     Process.flag(:trap_exit, true)
     name = options.name
-    metrics = options.metrics
-    handler_ids = EventHandler.attach(metrics, name, options.global_tags)
+
+    :ok =
+      Peep.Persistent.new(options)
+      |> Peep.Persistent.store()
+
+    :ok = Peep.Codegen.create(options)
+    handler_ids = EventHandler.attach(name)
 
     statsd_opts = options.statsd
     statsd_flush_interval = statsd_opts[:flush_interval_ms]
@@ -184,10 +269,6 @@ defmodule Peep do
       else
         nil
       end
-
-    :ok =
-      Peep.Persistent.new(options)
-      |> Peep.Persistent.store()
 
     state = %State{
       name: name,
@@ -228,9 +309,12 @@ defmodule Peep do
 
   @impl true
   def terminate(_reason, %{name: name, handler_ids: handler_ids}) do
+    Peep.Codegen.purge(name)
     Peep.Persistent.erase(name)
     EventHandler.detach(handler_ids)
   end
+
+  # private
 
   defp set_statsd_timer(interval) do
     Process.send_after(self(), :statsd_flush, interval)

--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -96,7 +96,7 @@ defmodule Peep do
     end
   end
 
-  def insert_metric(name, metric, value, tags) do
+  def insert_metric(name, metric, value, tags) when is_number(value) do
     case Peep.Persistent.fetch(name) do
       %Peep.Persistent{
         storage: {storage_mod, storage},
@@ -108,6 +108,8 @@ defmodule Peep do
         nil
     end
   end
+
+  def insert_metric(_name, _metric, _value, _tags), do: nil
 
   @doc """
   Returns measurements about the size of a running Peep's storage, in number of

--- a/lib/peep/codegen.ex
+++ b/lib/peep/codegen.ex
@@ -54,13 +54,14 @@ defmodule Peep.Codegen do
             keep: keep
           } = metric
 
-          if value =
-               keep?(keep, metadata) && fetch_measurement(measurement, measurements, metadata) do
-            tag_values = Map.merge(global_tags, tag_values.(metadata))
+          case keep?(keep, metadata) && fetch_measurement(measurement, measurements, metadata) do
+            value when is_number(value) ->
+              tag_values = Map.merge(global_tags, tag_values.(metadata))
+              tags = Map.new(global_tags_keys ++ tags, &{&1, Map.get(tag_values, &1, "")})
+              storage_mod.insert_metric(storage, id, metric, value, tags)
 
-            tags = Map.new(global_tags_keys ++ tags, &{&1, Map.get(tag_values, &1, "")})
-
-            storage_mod.insert_metric(storage, id, metric, value, tags)
+            _ ->
+              nil
           end
         end
 

--- a/lib/peep/codegen.ex
+++ b/lib/peep/codegen.ex
@@ -1,0 +1,102 @@
+defmodule Peep.Codegen do
+  @moduledoc false
+
+  alias Peep.Options
+  alias Peep.Persistent
+
+  def module(peep_name) do
+    :"Peep.Codegen.#{peep_name}"
+  end
+
+  def create(%Options{} = peep_options) do
+    %Options{name: name, global_tags: global_tags} = peep_options
+
+    module_name = module(name)
+    handle_event_ast = build_handle_event_ast(name)
+    other_funs_ast = other_funs_ast()
+
+    module_ast =
+      quote do
+        defmodule unquote(module_name) do
+          def global_tags(), do: unquote(Macro.escape(global_tags))
+          def name(), do: unquote(name)
+
+          unquote(handle_event_ast)
+          unquote(other_funs_ast)
+        end
+      end
+
+    [{_module, _bin}] = Code.compile_quoted(module_ast)
+    :ok
+  end
+
+  def purge(peep_name) do
+    :code.purge(module(peep_name))
+  end
+
+  defp build_handle_event_ast(peep_name) do
+    quote do
+      def handle_event(event, measurements, metadata, _) do
+        global_tags = global_tags()
+
+        %Persistent{
+          events_to_metrics: %{^event => metrics},
+          storage: {storage_mod, storage}
+        } = Persistent.fetch(unquote(peep_name))
+
+        for {metric, id} <- metrics do
+          %{
+            measurement: measurement,
+            tag_values: tag_values,
+            tags: tags,
+            keep: keep
+          } = metric
+
+          if value =
+               keep?(keep, metadata) && fetch_measurement(measurement, measurements, metadata) do
+            tag_values = Map.merge(global_tags, tag_values.(metadata))
+
+            tags = Map.new(tags, &{&1, Map.get(tag_values, &1, "")})
+
+            storage_mod.insert_metric(storage, id, metric, value, tags)
+          end
+        end
+
+        :ok
+      end
+    end
+  end
+
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
+  defp other_funs_ast() do
+    quote do
+      defp keep?(nil, _metadata), do: true
+      defp keep?(keep, metadata), do: keep.(metadata)
+
+      defp fetch_measurement(%Telemetry.Metrics.Counter{}, _measurements, _metadata) do
+        1
+      end
+
+      defp fetch_measurement(measurement, measurements, metadata) do
+        case measurement do
+          nil ->
+            nil
+
+          fun when is_function(fun, 1) ->
+            fun.(measurements)
+
+          fun when is_function(fun, 2) ->
+            fun.(measurements, metadata)
+
+          key ->
+            case measurements do
+              %{^key => nil} -> 1
+              %{^key => false} -> 1
+              %{^key => value} -> value
+              _ -> 1
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/peep/codegen.ex
+++ b/lib/peep/codegen.ex
@@ -19,6 +19,7 @@ defmodule Peep.Codegen do
       quote do
         defmodule unquote(module_name) do
           def global_tags(), do: unquote(Macro.escape(global_tags))
+          def global_tags_keys(), do: unquote(Macro.escape(Map.keys(global_tags)))
           def name(), do: unquote(name)
 
           unquote(handle_event_ast)
@@ -38,6 +39,7 @@ defmodule Peep.Codegen do
     quote do
       def handle_event(event, measurements, metadata, _) do
         global_tags = global_tags()
+        global_tags_keys = global_tags_keys()
 
         %Persistent{
           events_to_metrics: %{^event => metrics},
@@ -56,7 +58,7 @@ defmodule Peep.Codegen do
                keep?(keep, metadata) && fetch_measurement(measurement, measurements, metadata) do
             tag_values = Map.merge(global_tags, tag_values.(metadata))
 
-            tags = Map.new(tags, &{&1, Map.get(tag_values, &1, "")})
+            tags = Map.new(global_tags_keys ++ tags, &{&1, Map.get(tag_values, &1, "")})
 
             storage_mod.insert_metric(storage, id, metric, value, tags)
           end

--- a/lib/peep/event_handler.ex
+++ b/lib/peep/event_handler.ex
@@ -1,28 +1,21 @@
 defmodule Peep.EventHandler do
   @moduledoc false
-  require Logger
 
   @compile :inline
 
-  alias Telemetry.Metrics.{Counter, Summary, Distribution}
+  def attach(name) do
+    %Peep.Persistent{events_to_metrics: metrics_by_event} = Peep.Persistent.fetch(name)
+    module = Peep.Codegen.module(name)
 
-  def attach(metrics, name, global_tags) do
-    metrics_by_event = Enum.group_by(metrics, & &1.event_name)
-
-    for {event_name, metrics} <- metrics_by_event do
-      filtered_metrics = Enum.filter(metrics, &allow_metric?/1)
+    for {event_name, _metrics} <- metrics_by_event do
       handler_id = handler_id(event_name, name)
 
       :ok =
         :telemetry.attach(
           handler_id,
           event_name,
-          &__MODULE__.handle_event/4,
-          %{
-            name: name,
-            metrics: filtered_metrics,
-            global_tags: global_tags
-          }
+          &module.handle_event/4,
+          nil
         )
 
       handler_id
@@ -34,88 +27,7 @@ defmodule Peep.EventHandler do
     :ok
   end
 
-  def handle_event(_event, measurements, metadata, %{
-        name: name,
-        metrics: metrics,
-        global_tags: global_tags
-      }) do
-    for metric <- metrics do
-      %{
-        measurement: measurement,
-        tag_values: tag_values,
-        tags: tags,
-        keep: keep
-      } = metric
-
-      if value = keep?(keep, metadata) && fetch_measurement(measurement, measurements, metadata) do
-        tag_values =
-          global_tags
-          |> Map.merge(tag_values.(metadata))
-
-        tags = Map.new(tags, &{&1, Map.get(tag_values, &1, "")})
-
-        Peep.insert_metric(name, metric, value, tags)
-      end
-    end
-  end
-
   defp handler_id(event_name, peep_name) do
     {__MODULE__, peep_name, event_name}
-  end
-
-  defp keep?(nil, _metadata), do: true
-  defp keep?(keep, metadata), do: keep.(metadata)
-
-  defp fetch_measurement(%Counter{}, _measurements, _metadata) do
-    1
-  end
-
-  defp fetch_measurement(measurement, measurements, metadata) do
-    case measurement do
-      nil ->
-        nil
-
-      fun when is_function(fun, 1) ->
-        fun.(measurements)
-
-      fun when is_function(fun, 2) ->
-        fun.(measurements, metadata)
-
-      key ->
-        case measurements do
-          %{^key => nil} -> 1
-          %{^key => false} -> 1
-          %{^key => value} -> value
-          _ -> 1
-        end
-    end
-  end
-
-  defp allow_metric?(%Summary{} = metric) do
-    Logger.warning("The summary metric type is unsupported. Dropping #{inspect(metric.name)}")
-    false
-  end
-
-  defp allow_metric?(%Distribution{reporter_options: opts} = metric) do
-    key = :max_value
-
-    case Keyword.get(opts, key) do
-      nil ->
-        true
-
-      n when is_number(n) ->
-        true
-
-      _ ->
-        Logger.warning(
-          "Distributions must have a numeric value assigned to #{inspect(key)} in reporter_options. Dropping #{inspect(metric.name)}"
-        )
-
-        false
-    end
-  end
-
-  defp allow_metric?(_) do
-    true
   end
 end

--- a/lib/peep/statsd/packet.ex
+++ b/lib/peep/statsd/packet.ex
@@ -1,7 +1,6 @@
 defmodule Peep.Statsd.Packet do
   @moduledoc false
   alias __MODULE__
-  require Logger
 
   defstruct keys: [], lines: [], remaining: nil, max_size: nil
 

--- a/lib/peep/storage.ex
+++ b/lib/peep/storage.ex
@@ -19,17 +19,17 @@ defmodule Peep.Storage do
   @doc """
   Stores a sample metric
   """
-  @callback insert_metric(term(), Metrics.t(), term(), map()) :: any()
+  @callback insert_metric(term(), Peep.metric_id(), Metrics.t(), term(), map()) :: any()
 
   @doc """
   Retrieves all stored metrics
   """
-  @callback get_all_metrics(term()) :: map()
+  @callback get_all_metrics(term(), Peep.Persistent.t()) :: map()
 
   @doc """
   Retrieves a single stored metric
   """
-  @callback get_metric(term(), Metrics.t(), map()) :: any()
+  @callback get_metric(term(), Peep.metric_id(), Metrics.t(), map()) :: any()
 
   @doc """
   Removes metrics whose metadata contains a specific tag key and value.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Peep.MixProject do
   use Mix.Project
 
-  @version "3.5.0"
+  @version "4.0.0"
 
   def project do
     [

--- a/test/codegen_test.exs
+++ b/test/codegen_test.exs
@@ -1,0 +1,39 @@
+defmodule Codegen.Test do
+  use ExUnit.Case
+
+  alias Peep.Support.StorageCounter
+  alias Telemetry.Metrics
+
+  defp metrics do
+    counter = Metrics.counter("peep.counter", event_name: [:counter])
+    sum = Metrics.sum("peep.sum", event_name: [:sum], measurement: :count)
+
+    last_value =
+      Metrics.last_value("peep.gauge", event_name: [:gauge], measurement: :value)
+
+    distribution =
+      Metrics.distribution("peep.dist",
+        event_name: [:dist],
+        measurement: :value,
+        reporter_options: [max_value: 100]
+      )
+
+    [counter, sum, last_value, distribution]
+  end
+
+  test "module exists after Peep starts" do
+    name = StorageCounter.fresh_id()
+
+    options = [
+      name: name,
+      metrics: metrics()
+    ]
+
+    assert {:ok, _pid} = Peep.start_link(options)
+    module = Peep.Codegen.module(name)
+
+    for {%{event_name: event_name} = metric, id} <- metrics() do
+      assert module.metrics(event_name) == [{metric, id}]
+    end
+  end
+end

--- a/test/peep_test.exs
+++ b/test/peep_test.exs
@@ -41,7 +41,7 @@ defmodule PeepTest do
   test "a worker with non-empty global_tags applies to all metrics" do
     name = :"#{__MODULE__}_global_tags"
 
-    tags = %{foo: "bar", baz: "quux"}
+    tags = %{foo: "bar", baz: "quux", service: "my-app", env: "production"}
     tag_keys = [:foo, :baz]
 
     counter = Metrics.counter("peep.counter", event_name: [:counter], tags: tag_keys)

--- a/test/peep_test.exs
+++ b/test/peep_test.exs
@@ -140,4 +140,33 @@ defmodule PeepTest do
 
     assert [] == :telemetry.list_handlers(prefix)
   end
+
+  test "assign_ids" do
+    metrics =
+      [c, s, d, l] = [
+        Metrics.counter("one.two"),
+        Metrics.sum("one.two"),
+        Metrics.distribution("three.four"),
+        Metrics.last_value("five.six")
+      ]
+
+    expected_by_event = %{
+      [:one] => [{c, 1}, {s, 2}],
+      [:three] => [{d, 3}],
+      [:five] => [{l, 4}]
+    }
+
+    expected_by_id = %{1 => c, 2 => s, 3 => d, 4 => l}
+    expected_by_metric = %{c => 1, s => 2, d => 3, l => 4}
+
+    %{
+      events_to_metrics: actual_by_event,
+      ids_to_metrics: actual_by_id,
+      metrics_to_ids: actual_by_metric
+    } = Peep.assign_metric_ids(metrics)
+
+    assert actual_by_event == expected_by_event
+    assert actual_by_id == expected_by_id
+    assert actual_by_metric == expected_by_metric
+  end
 end

--- a/test/prometheus_test.exs
+++ b/test/prometheus_test.exs
@@ -332,39 +332,6 @@ defmodule PrometheusTest do
       assert export(name) == lines_to_string(expected)
     end
 
-    test "#{impl} - non-number values" do
-      name = StorageCounter.fresh_id()
-
-      last_value =
-        Metrics.last_value(
-          "prometheus.test.gauge",
-          description: "a last_value",
-          tags: [:from]
-        )
-
-      opts = [
-        name: name,
-        metrics: [last_value],
-        storage: unquote(impl)
-      ]
-
-      {:ok, _pid} = Peep.start_link(opts)
-
-      Peep.insert_metric(name, last_value, true, %{from: true})
-      Peep.insert_metric(name, last_value, false, %{from: false})
-      Peep.insert_metric(name, last_value, nil, %{from: nil})
-
-      expected = [
-        "# HELP prometheus_test_gauge a last_value",
-        "# TYPE prometheus_test_gauge gauge",
-        ~s(prometheus_test_gauge{from="false"} 0),
-        ~s(prometheus_test_gauge{from="nil"} 0),
-        ~s(prometheus_test_gauge{from="true"} 1)
-      ]
-
-      assert export(name) == lines_to_string(expected)
-    end
-
     test "#{impl} - regression: label escaping" do
       name = StorageCounter.fresh_id()
 


### PR DESCRIPTION
Peep.Codegen creates a new module when Peep starts. That module contains copies of some of the functionality moved out of Peep.EventHandler, as well as its own `handle_event/4` function which is be passed as a callback when attaching to :telemetry events. This allows for Peep to avoid adding arguments to be passed to the callback function, avoiding copying multiple metrics structs out of :telemetry's ETS table.

In addition, a Peep's metrics are now stored in the %Peep.Persistent{} struct stored using :persistent_term, and are each given their own id. These ids replace the use of the metrics structs as keys in ETS tables. This results in faster interactions with ETS, as integer ids hash much faster than metrics structs.

### Why?

It's quite a bit faster. Peep spends less time copying data, and less time hashing keys for objects stored in ETS. I don't have microbenchmarks that show this, but I collected perf data from a heavily-loaded service running this branch of Peep in production, which showed some very promising results:

* Calls to :telemetry went from appearing in 15% of samples down to 11%.
* Calls to copy_shallow_x and build_term_list went from appearing in 3.2% of samples down to 1.7%.
* Calls to make_internal_hash went from appearing in 2.0% of samples down to 0.5%.
* p50, p95, and p99 for request latency for the service all dropped. The service was already quite fast, so the absolute decrease is rather small, but p50 dropped by 100 microseconds.