### PR TITLE
Dispatch Telemetry event when reading storage size

### DIFF
--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -115,10 +115,15 @@ defmodule Peep do
   Returns measurements about the size of a running Peep's storage, in number of
   ETS elements and in bytes of memory.
   """
+  @spec storage_size(atom()) :: %{size: non_neg_integer(), memory: non_neg_integer()}
   def storage_size(name) do
     case Peep.Persistent.storage(name) do
       {storage_mod, storage} ->
-        storage_mod.storage_size(storage)
+        measurements = storage_mod.storage_size(storage)
+
+        Peep.Telemetry.storage_size(measurements, name, storage_mod)
+
+        measurements
 
       _ ->
         nil

--- a/lib/peep/telemetry.ex
+++ b/lib/peep/telemetry.ex
@@ -19,4 +19,10 @@ defmodule Peep.Telemetry do
     metadata = %{reason: reason}
     :telemetry.execute([:peep, :packet, :error], measurements, metadata)
   end
+
+  def storage_size(sizes, name, mod) do
+    measurements = sizes
+    metadata = %{name: name, mod: mod}
+    :telemetry.execute([:peep, :storage], measurements, metadata)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule Peep.MixProject do
   defp deps do
     [
       {:nimble_options, "~> 1.1"},
+      {:telemetry, "~> 1.0"},
       {:telemetry_metrics, "~> 1.0"},
       # testing, docs, & linting
       {:bandit, "~> 1.6", only: [:test], runtime: false},


### PR DESCRIPTION
This makes this function usable with `telemetry_pooler` to record size of Peep storage.