### PR TITLE
feat: optimise generated module code to reduce performance impact

### DIFF
--- a/lib/peep/persistent.ex
+++ b/lib/peep/persistent.ex
@@ -2,6 +2,8 @@ defmodule Peep.Persistent do
   @moduledoc false
   defstruct [:name, :storage, :events_to_metrics, :ids_to_metrics, :metrics_to_ids]
 
+  @compile {:inline, key: 1, fetch: 1}
+
   @type name() :: atom()
 
   @typep storage_default() :: {Peep.Storage.ETS, :ets.tid()}
@@ -74,6 +76,12 @@ defmodule Peep.Persistent do
 
       _ ->
         nil
+    end
+  end
+
+  defmacro fast_fetch(name) when is_atom(name) do
+    quote do
+      :persistent_term.get(unquote(key(name)), nil)
     end
   end
 


### PR DESCRIPTION
`handle_event/4` function is *very* time sensitive function, especially in high throughput systems where it is called a lot, so every single bit of performance matters.

Here we are using more direct approach to iterate over list with `:lists.foreach/2` which is BIF and avoids dynamic dispatch, as we know that `metrics` is always list.

It inlines function calls to reduce overhead and well as optimise fetching tags values from metadata. It slightly changes behaviour there as non-existent keys will be non-existent in metadata instead of containing empty strings.