### PR TITLE
Move validations in __using__ inside quote

### DIFF
--- a/lib/peep/buckets/custom.ex
+++ b/lib/peep/buckets/custom.ex
@@ -6,9 +6,11 @@ defmodule Peep.Buckets.Custom do
   For an example, look at the source of `Peep.Buckets.PowersOfTen`.
   """
 
-  defmacro __using__(buckets: buckets) do
+  defmacro __using__(opts) do
+    Module.put_attribute(__CALLER__.module, :buckets, Keyword.fetch!(opts, :buckets))
+
     quote do
-      @buckets :lists.usort(unquote(buckets))
+      @buckets :lists.usort(unquote(Module.get_attribute(__CALLER__.module, :buckets)))
 
       unless Enum.all?(@buckets, &is_number/1) do
         raise ArgumentError, "expected buckets to be a list of numbers, got: #{@buckets}"

--- a/lib/peep/buckets/custom.ex
+++ b/lib/peep/buckets/custom.ex
@@ -24,34 +24,18 @@ defmodule Peep.Buckets.Custom do
       @impl true
       def number_of_buckets(_), do: @number_of_buckets
 
+      @int_buckets unquote(__MODULE__).int_buckets(@buckets, nil, 0)
+      @number_of_int_buckets length(@int_buckets)
+      @float_buckets Enum.with_index(Enum.map(@buckets, &(&1 * 1.0)))
+      @number_of_float_buckets length(@float_buckets)
+
       @impl true
       def bucket_for(x, _) when is_integer(x) do
-        buckets = @buckets
-        int_buckets = int_buckets(buckets, nil, 0)
-
-        build_bucket_tree(int_buckets, length(int_buckets), @number_of_buckets, x)
+        build_bucket_tree(@int_buckets, @number_of_int_buckets, @number_of_buckets, x)
       end
 
       def bucket_for(x, _) when is_float(x) do
-        buckets = @buckets
-
-        float_buckets =
-          buckets
-          |> Enum.map(&(&1 * 1.0))
-          |> Enum.with_index()
-
-        build_bucket_tree(float_buckets, length(float_buckets), @number_of_buckets, x)
-      end
-
-      defp int_buckets([], _prev, _counter) do
-        []
-      end
-
-      defp int_buckets([curr | tail], prev, counter) do
-        case ceil(curr) do
-          ^prev -> int_buckets(tail, prev, counter + 1)
-          curr -> [{curr, counter} | int_buckets(tail, curr, counter + 1)]
-        end
+        build_bucket_tree(@float_buckets, @number_of_float_buckets, @number_of_buckets, x)
       end
 
       defp build_bucket_tree([{bound, lval}], 1, _rval, x) when x < bound, do: lval
@@ -87,6 +71,18 @@ defmodule Peep.Buckets.Custom do
       end
 
       def upper_bound(_, _), do: "+Inf"
+    end
+  end
+
+  @doc false
+  def int_buckets([], _prev, _counter) do
+    []
+  end
+
+  def int_buckets([curr | tail], prev, counter) do
+    case ceil(curr) do
+      ^prev -> int_buckets(tail, prev, counter + 1)
+      curr -> [{curr, counter} | int_buckets(tail, curr, counter + 1)]
     end
   end
 end

--- a/lib/peep/buckets/custom.ex
+++ b/lib/peep/buckets/custom.ex
@@ -6,140 +6,85 @@ defmodule Peep.Buckets.Custom do
   For an example, look at the source of `Peep.Buckets.PowersOfTen`.
   """
 
-  defmacro __using__(opts) do
-    buckets =
-      Keyword.fetch!(opts, :buckets)
-      |> :lists.usort()
-
-    unless Enum.all?(buckets, &is_number/1) do
-      raise ArgumentError, "expected buckets to be a list of numbers, got: #{buckets}"
-    end
-
-    number_of_buckets = length(buckets)
-
+  defmacro __using__(buckets: buckets) do
     quote do
+      @buckets :lists.usort(unquote(buckets))
+
+      unless Enum.all?(@buckets, &is_number/1) do
+        raise ArgumentError, "expected buckets to be a list of numbers, got: #{@buckets}"
+      end
+
       @behaviour Peep.Buckets
 
       @impl true
       def config(_), do: %{}
 
       @impl true
-      def number_of_buckets(_), do: unquote(number_of_buckets)
+      def number_of_buckets(_), do: length(@buckets)
 
       @impl true
-      unquote(bucket_for_ast(buckets))
+      def bucket_for(x, _) when is_integer(x) do
+        buckets = @buckets
+        int_buckets = int_buckets(buckets, nil, 0)
 
-      @impl true
-      unquote(upper_bound_ast(buckets))
-    end
-  end
-
-  ## Bucket binary search
-
-  defp bucket_for_ast(buckets) do
-    int_buckets = int_buckets(buckets, nil, 0)
-
-    float_buckets =
-      buckets
-      |> Enum.map(&(&1 * 1.0))
-      |> Enum.with_index()
-
-    variable = Macro.var(:x, nil)
-
-    int_length = length(int_buckets)
-    int_tree = build_bucket_tree(int_buckets, int_length, length(buckets), variable)
-
-    float_length = length(float_buckets)
-    float_tree = build_bucket_tree(float_buckets, float_length, length(buckets), variable)
-
-    quote do
-      def bucket_for(unquote(variable), _) when is_integer(unquote(variable)) do
-        unquote(int_tree)
+        build_bucket_tree(int_buckets, length(int_buckets), length(buckets), x)
       end
 
-      def bucket_for(unquote(variable), _) when is_float(unquote(variable)) do
-        unquote(float_tree)
+      def bucket_for(x, _) when is_float(x) do
+        buckets = @buckets
+
+        float_buckets =
+          buckets
+          |> Enum.map(&(&1 * 1.0))
+          |> Enum.with_index()
+
+        build_bucket_tree(float_buckets, length(float_buckets), length(buckets), x)
       end
-    end
 
-    # |> tap(&IO.puts(Code.format_string!(Macro.to_string(&1))))
-  end
-
-  defp build_bucket_tree([{bound, lval}], 1, rval, variable) do
-    quote do
-      case unquote(variable) do
-        x when x < unquote(bound) ->
-          unquote(lval)
-
-        _ ->
-          unquote(rval)
+      defp int_buckets([], _prev, _counter) do
+        []
       end
-    end
-  end
 
-  defp build_bucket_tree([{lbound, lval}, {rbound, mval}], 2, rval, variable) do
-    quote do
-      case unquote(variable) do
-        x when x < unquote(lbound) ->
-          unquote(lval)
-
-        x when x < unquote(rbound) ->
-          unquote(mval)
-
-        _ ->
-          unquote(rval)
-      end
-    end
-  end
-
-  defp build_bucket_tree(bounds, length, rval, variable) do
-    llength = div(length, 2)
-    rlength = length - llength - 1
-
-    {lbounds, rbounds} = Enum.split(bounds, llength)
-    [{bound, lval} | rbounds] = rbounds
-
-    quote do
-      case unquote(variable) do
-        x when x < unquote(bound) ->
-          unquote(build_bucket_tree(lbounds, llength, lval, variable))
-
-        _ ->
-          unquote(build_bucket_tree(rbounds, rlength, rval, variable))
-      end
-    end
-  end
-
-  defp int_buckets([], _prev, _counter) do
-    []
-  end
-
-  defp int_buckets([curr | tail], prev, counter) do
-    case ceil(curr) do
-      ^prev -> int_buckets(tail, prev, counter + 1)
-      curr -> [{curr, counter} | int_buckets(tail, curr, counter + 1)]
-    end
-  end
-
-  ## Upper bound
-
-  defp upper_bound_ast(buckets) do
-    bucket_defns =
-      for {boundary, bucket_idx} <- Enum.with_index(buckets) do
-        quote do
-          def upper_bound(unquote(bucket_idx), _), do: unquote(int_to_float_string(boundary))
+      defp int_buckets([curr | tail], prev, counter) do
+        case ceil(curr) do
+          ^prev -> int_buckets(tail, prev, counter + 1)
+          curr -> [{curr, counter} | int_buckets(tail, curr, counter + 1)]
         end
       end
 
-    final_defn =
-      quote do
-        def upper_bound(_, _), do: "+Inf"
+      defp build_bucket_tree([{bound, lval}], 1, _rval, x) when x < bound, do: lval
+      defp build_bucket_tree([{bound, _lval}], 1, rval, _x), do: rval
+
+      defp build_bucket_tree([{lbound, lval}, {_rbound, _mval}], 2, rval, x) when x < lbound,
+        do: lval
+
+      defp build_bucket_tree([{_lbound, _lval}, {rbound, mval}], 2, _rval, x) when x < rbound,
+        do: mval
+
+      defp build_bucket_tree([{_lbound, _lval}, {_rbound, _mval}], 2, rval, _x), do: rval
+
+      defp build_bucket_tree(bounds, length, rval, x) do
+        llength = div(length, 2)
+        rlength = length - llength - 1
+
+        {lbounds, rbounds} = Enum.split(bounds, llength)
+        [{bound, lval} | rbounds] = rbounds
+
+        case x < bound do
+          true -> build_bucket_tree(lbounds, llength, lval, x)
+          false -> build_bucket_tree(rbounds, rlength, rval, x)
+        end
       end
 
-    bucket_defns ++ [final_defn]
-  end
+      @impl true
+      for {boundary, bucket_idx} <- Enum.with_index(@buckets) do
+        @boundary boundary
+        @bucket_idx bucket_idx
 
-  defp int_to_float_string(int) do
-    to_string(int * 1.0)
+        def upper_bound(@bucket_idx, _), do: to_string(@boundary * 1.0)
+      end
+
+      def upper_bound(_, _), do: "+Inf"
+    end
   end
 end

--- a/lib/peep/buckets/custom.ex
+++ b/lib/peep/buckets/custom.ex
@@ -29,7 +29,7 @@ defmodule Peep.Buckets.Custom do
         buckets = @buckets
         int_buckets = int_buckets(buckets, nil, 0)
 
-        build_bucket_tree(int_buckets, length(int_buckets), length(buckets), x)
+        build_bucket_tree(int_buckets, length(int_buckets), @number_of_buckets, x)
       end
 
       def bucket_for(x, _) when is_float(x) do
@@ -40,7 +40,7 @@ defmodule Peep.Buckets.Custom do
           |> Enum.map(&(&1 * 1.0))
           |> Enum.with_index()
 
-        build_bucket_tree(float_buckets, length(float_buckets), length(buckets), x)
+        build_bucket_tree(float_buckets, length(float_buckets), @number_of_buckets, x)
       end
 
       defp int_buckets([], _prev, _counter) do

--- a/lib/peep/buckets/custom.ex
+++ b/lib/peep/buckets/custom.ex
@@ -14,13 +14,15 @@ defmodule Peep.Buckets.Custom do
         raise ArgumentError, "expected buckets to be a list of numbers, got: #{@buckets}"
       end
 
+      @number_of_buckets length(@buckets)
+
       @behaviour Peep.Buckets
 
       @impl true
       def config(_), do: %{}
 
       @impl true
-      def number_of_buckets(_), do: length(@buckets)
+      def number_of_buckets(_), do: @number_of_buckets
 
       @impl true
       def bucket_for(x, _) when is_integer(x) do

--- a/test/buckets_test.exs
+++ b/test/buckets_test.exs
@@ -80,4 +80,19 @@ defmodule BucketsTest do
     assert 2 = module.bucket_for(2, %{})
     assert 3 = module.bucket_for(3, %{})
   end
+
+  test "allows passing `:timer` expressions" do
+    [{module, _binary}] =
+      quote do
+        defmodule TimerBuckets do
+          use Peep.Buckets.Custom, buckets: [:timer.seconds(1), :timer.seconds(2)]
+        end
+      end
+      |> Code.compile_quoted()
+
+    assert 2 = module.number_of_buckets(%{})
+    assert 0 = module.bucket_for(:timer.seconds(0), %{})
+    assert 1 = module.bucket_for(:timer.seconds(1), %{})
+    assert 2 = module.bucket_for(:timer.seconds(2), %{})
+  end
 end


### PR DESCRIPTION
Fixes #44

Alternative fix to #45 which relies on moving the validation inside the quote-block, and adapting the other functions to work with 'regular' data instead of AST.