### PR TITLE
Conform to OpenMetrics specification

### DIFF
--- a/lib/peep/prometheus.ex
+++ b/lib/peep/prometheus.ex
@@ -11,7 +11,7 @@ defmodule Peep.Prometheus do
   alias Telemetry.Metrics.{Counter, Distribution, LastValue, Sum}
 
   def export(metrics) do
-    Enum.map(metrics, &format/1)
+    [Enum.map(metrics, &format/1), "# EOF\n"]
   end
 
   defp format({%Counter{}, _series} = metric) do

--- a/test/prometheus_test.exs
+++ b/test/prometheus_test.exs
@@ -374,6 +374,7 @@ defmodule PrometheusTest do
   defp lines_to_string(lines) do
     lines
     |> Enum.map(&[&1, ?\n])
+    |> Enum.concat(["# EOF\n"])
     |> IO.iodata_to_binary()
   end
 end


### PR DESCRIPTION
[OpenMetrics][OM] requires that each export document ends with comment containing string `EOF`. This change is fully compatible with Prometheus export format, but increases compatibility with OpenMetrics specs.

[OM]: https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md