### PR TITLE
Fix unable to open StatsD socket. reason: :emfile

### DIFF
--- a/lib/peep/statsd.ex
+++ b/lib/peep/statsd.ex
@@ -86,6 +86,7 @@ defmodule Peep.Statsd do
           %__MODULE__{state | statsd_opts: new_opts}
 
         {:error, _reason} ->
+          :gen_udp.close(socket)
           %__MODULE__{state | socket: nil}
       end
 


### PR DESCRIPTION
If StatsD is not available and the packet transmission fails, `Peep.StatsD.send_packets/3` removes the socket from the state but does not close it.

This leads to a situation where we try to open a new socket every few seconds and don't close any of them and end up hitting the maximum file descriptors limit.

This change simply closes the socket, freeing up the file descriptor.

**Error:**
```
[error] 2025-09-12 17:15:57.855 unable to open StatsD socket. reason: :emfile
        {line=150 pid=<0.440.0> file=lib/peep/statsd.ex domain=elixir application=peep mfa=Peep.Statsd.try_to_open_socket/1 }
```