### PR TITLE
fix: use bracket notation for statsd keyword list access in init/1

### DIFF
--- a/lib/peep.ex
+++ b/lib/peep.ex
@@ -212,7 +212,7 @@ defmodule Peep do
 
     statsd_state =
       if statsd_opts do
-        set_statsd_timer(statsd_opts.flush_interval_ms)
+        set_statsd_timer(statsd_opts[:flush_interval_ms])
         Statsd.make_state(statsd_opts)
       else
         nil

--- a/test/statsd_test.exs
+++ b/test/statsd_test.exs
@@ -6,6 +6,10 @@ defmodule StatsdTest do
 
   @impls [:default, :striped]
 
+  test "starts successfully with statsd options configured" do
+    assert _name = Peep.Test.start_peep!(metrics: [], statsd: [host: "127.0.0.1", port: 8125])
+  end
+
   for impl <- @impls do
     describe "#{impl} - global metadata" do
       test "is present in formatted output" do


### PR DESCRIPTION
## Summary

- Fixes a `BadMapError` crash on startup when `statsd` options are configured
- `statsd_opts` is a keyword list (per the `Peep.Options` schema: `type: {:or, [nil, {:keyword_list, ...}]}`), so it must be accessed with bracket notation, not dot notation
- Line 244 in the same function already uses `statsd_opts[:flush_interval_ms]` correctly — line 215 was inconsistent

The bug was introduced in v5.0.0 when `options` was refactored from a keyword list to a `%Peep.Options{}` struct. The dot-notation conversion was incorrectly applied to `statsd_opts`, which is a keyword list field *inside* the struct.